### PR TITLE
Add scheme and port to the audience sent to the verifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,11 +105,8 @@ If you do not wish to automatically create user accounts, you may manually verif
           if not form.is_valid():
               # do something
           host = request.get_host()
-          if ':' in host:
-              host, port = host.split(':')
-          else:
-              port = '80'
-          audience = get_audience(host, port)
+          https = request.is_secure()
+          audience = get_audience(host, https)
           result = verify(form.cleaned_data['assertion'], audience)
           # ...
 

--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -15,7 +15,6 @@ from django.contrib.auth.models import User
 
 log = logging.getLogger(__name__)
 
-DEFAULT_HTTP_PORT = '80'
 DEFAULT_HTTP_TIMEOUT = 5
 DEFAULT_VERIFICATION_URL = 'https://browserid.org/verify'
 OKAY_RESPONSE = 'okay'
@@ -25,10 +24,19 @@ class BrowserIDBackend(object):
     supports_anonymous_user = False
     supports_object_permissions = False
 
-    def get_audience(self, host, port):
-        if port and port != DEFAULT_HTTP_PORT:
-            return u'%s:%s' % (host, port)
-        return host
+    def get_audience(self, host, https):
+        if https:
+            scheme = 'https'
+            default_port = 443
+        else:
+            scheme = 'http'
+            default_port = 80
+
+        audience = "%s://%s" % (scheme, host)
+        if ':' in host:
+            return audience
+        else:
+            return "%s:%s" % (audience, default_port)
 
     def _verify_http_request(self, url, qs):
         timeout = getattr(settings, 'BROWSERID_HTTP_TIMEOUT',
@@ -58,8 +66,8 @@ class BrowserIDBackend(object):
         """Return object for a newly created user account."""
         return User.objects.create_user(username, email)
 
-    def authenticate(self, assertion=None, host=None, port=None):
-        result = self.verify(assertion, self.get_audience(host, port))
+    def authenticate(self, assertion=None, host=None, https=None):
+        result = self.verify(assertion, self.get_audience(host, https))
         if result is None:
             return None
         email = result['email']

--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -6,12 +6,6 @@ from django.views.decorators.http import require_POST
 from django_browserid.forms import BrowserIDForm
 
 
-def _get_host_and_port(request):
-    """Return host, port if port is nonstandard or host, '80' otherwise"""
-    host = request.get_host()
-    return ':' in host and host.split(':') or (host, '80')
-
-
 @require_POST
 def verify(request, redirect_field_name=auth.REDIRECT_FIELD_NAME):
     """Process browserid assertions."""
@@ -22,8 +16,8 @@ def verify(request, redirect_field_name=auth.REDIRECT_FIELD_NAME):
     form = BrowserIDForm(data=request.POST)
     if form.is_valid():
         assertion = form.cleaned_data['assertion']
-        host, port = _get_host_and_port(request)
-        user = auth.authenticate(assertion=assertion, host=host, port=port)
+        user = auth.authenticate(assertion=assertion, host=request.get_host(),
+                                 https=request.is_secure())
         if user is not None and user.is_active:
             auth.login(request, user)
             return HttpResponseRedirect(redirect_to)


### PR DESCRIPTION
This an update to make it work with the new verifier that rolled into production as part of train 2011-10-20.

Unfortunately this breaks backward compatibility with any existing users of this code, but there's not really any way around it as far as I can tell since the auth plugin needs to know whether or not the host is on HTTPS to be able to set the right scheme.
