### PR TITLE
Put json.loads in a try/except

### DIFF
--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -121,7 +121,14 @@ class BrowserIDBackend(object):
         headers = {'Content-type': 'application/x-www-form-urlencoded'}
         resp, content = client.request(url, 'POST', body=qs, headers=headers)
 
-        return json.loads(content)
+        try:
+            rv = json.loads(content)
+        except ValueError:
+            log.debug('Failed to decode JSON. Resp: %s, Content: %s' % (
+                resp, content))
+            return dict(status='failure')
+
+        return rv
 
     def verify(self, assertion, audience):
         """Verify assertion using an external verification service."""


### PR DESCRIPTION
On AMO we're seeing the following errors.  This will at least catch them and log what's going on...

```
Traceback (most recent call last):

 File "/data/www/apps-preview-dev.allizom.org/zamboni/vendor/src/django/django/core/handlers/base.py", line 111, in get_response
   response = callback(request, *callback_args, **callback_kwargs)

 File "/data/www/apps-preview-dev.allizom.org/zamboni/apps/amo/decorators.py", line 49, in wrapper
   return f(request, *args, **kw)

 File "/data/www/apps-preview-dev.allizom.org/zamboni/apps/users/views.py", line 325, in browserid_login
   assertion=request.POST['assertion'])

 File "/data/www/apps-preview-dev.allizom.org/zamboni/apps/users/views.py", line 290, in browserid_authenticate
   result = backend.verify(assertion, settings.SITE_URL)

 File "/data/www/apps-preview-dev.allizom.org/zamboni/vendor/src/django-browserid/django_browserid/auth.py", line 65, in verify
   'audience': audience

 File "/data/www/apps-preview-dev.allizom.org/zamboni/vendor/src/django-browserid/django_browserid/auth.py", line 57, in _verify_http_request
   return json.loads(content)

 File "/usr/lib64/python2.6/json/__init__.py", line 307, in loads
   return _default_decoder.decode(s)

 File "/usr/lib64/python2.6/json/decoder.py", line 319, in decode
   obj, end = self.raw_decode(s, idx=_w(s, 0).end())

 File "/usr/lib64/python2.6/json/decoder.py", line 338, in raw_decode
   raise ValueError("No JSON object could be decoded")

ValueError: No JSON object could be decoded
```
