### PR TITLE
Make verify a standalone function.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Creating User Accounts
 
 If you want full control over account creation, don't use django-browserid's ``browserid_verify`` view. Create your own view and use ``verify`` to manually verify a BrowserID assertion with something like the following::
 
-   from django_browserid.auth import get_audience, verify
+   from django_browserid import get_audience, verify
    from django_browserid.forms import BrowserIDForm
 
 

--- a/django_browserid/__init__.py
+++ b/django_browserid/__init__.py
@@ -1,2 +1,6 @@
+from django_browserid.auth import BrowserIDBackend
+from django_browserid.base import get_audience, verify
+
+
 VERSION = (0, 1)
 __version__ = '.'.join(map(str, VERSION))

--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -1,88 +1,21 @@
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 import base64
 import hashlib
 import logging
-import urllib
-
-import requests
+from warnings import warn
 
 from django.conf import settings
 from django.contrib.auth.models import User
 
+from django_browserid.base import get_audience as base_get_audience, verify
+
+
 log = logging.getLogger(__name__)
 
-DEFAULT_HTTP_TIMEOUT = 5
-DEFAULT_VERIFICATION_URL = 'https://browserid.org/verify'
-OKAY_RESPONSE = 'okay'
 
-
-def get_audience(request):
-    """Uses Django settings to format the audience.
-
-    To use this function, make sure there is either a SITE_URL in
-    your settings.py file or PROTOCOL and DOMAIN.
-
-    Examples using SITE_URL:
-        SITE_URL = 'http://127.0.0.1:8001'
-        SITE_URL = 'https://example.com'
-        SITE_URL = 'http://example.com'
-
-    If you don't have a SITE_URL you can also use these varables:
-    PROTOCOL, DOMAIN, and (optionally) PORT.
-    Example 1:
-        PROTOCOL = 'https://'
-        DOMAIN = 'example.com'
-
-    Example 2:
-        PROTOCOL = 'http://'
-        DOMAIN = '127.0.0.1'
-        PORT = '8001'
-
-    If none are set, we trust the request to populate the audience.
-    This is *not secure*!
-    """
-    site_url = getattr(settings, 'SITE_URL', False)
-
-    # Note audience based on request for developer warnings
-    if request.is_secure():
-        req_proto = 'https://'
-    else:
-        req_proto = 'http://'
-    req_domain = request.get_host()
-
-    # If we don't define it explicitly
-    if not site_url:
-        protocol = getattr(settings, 'PROTOCOL', req_proto)
-        if not getattr(settings, 'DOMAIN'):
-            log.warning('django-browserid WARNING you are missing '
-                        'settings.SITE_URL. This is not a secure way '
-                        'to verify assertions. Please fix me. '
-                        'Setting domain to %s.' % req_domain)
-
-        # DOMAIN is example.com req_domain is example.com:8001
-        domain = getattr(settings, 'DOMAIN', req_domain.split(':')[0])
-
-        standards = {'https://': 443, 'http://': 80}
-        if ':' in req_domain:
-            req_port = req_domain.split(':')[1]
-        else:
-            req_port = None
-        port = getattr(settings, 'PORT', req_port or standards[protocol])
-        if port == standards[protocol]:
-            site_url = ''.join(map(str, (protocol, domain)))
-        else:
-            site_url = ''.join(map(str, (protocol, domain, ':', port)))
-
-    req_url = "%s%s" % (req_proto, req_domain)
-    if site_url != "%s%s" % (req_proto, req_domain):
-        log.warning('Misconfigured SITE_URL? settings has [%s], but '
-                    'actual request was [%s] BrowserID may fail on '
-                    'audience' % (site_url, req_url))
-    return site_url
+def get_audience(*args):
+    warn('Deprecated, please use the standalone function '
+         'django_browserid.get_audience instead.', DeprecationWarning)
+    return base_get_audience(*args)
 
 
 def default_username_algo(email):
@@ -98,44 +31,10 @@ class BrowserIDBackend(object):
     supports_anonymous_user = False
     supports_object_permissions = False
 
-    def _verify_http_request(self, url, qs):
-        parameters = {'data': qs}
-        parameters['params'] = {'timeout': getattr(
-                settings, 'BROWSERID_HTTP_TIMEOUT', DEFAULT_HTTP_TIMEOUT)}
-        parameters['proxies'] = getattr(settings, 'BROWSERID_PROXY_INFO', None)
-        parameters['verify'] = getattr(settings, 'BROWSERID_DISABLE_CERT_CHECK', False)
-        if not parameters['verify']:
-            parameters['verify'] = getattr(settings, 'BROWSERID_CACERT_FILE', True)
-
-        parameters['headers'] = {'Content-type': 'application/x-www-form-urlencoded'}
-        r = requests.post(url, **parameters)
-
-        try:
-            rv = json.loads(r.content)
-        except ValueError:
-            log.debug('Failed to decode JSON. Resp: %s, Content: %s' % (
-                r.status_code, r.content))
-            return dict(status='failure')
-
-        return rv
-
-    def verify(self, assertion, audience):
-        """Verify assertion using an external verification service."""
-        verify_url = getattr(settings, 'BROWSERID_VERIFICATION_URL',
-                             DEFAULT_VERIFICATION_URL)
-
-        log.info("Verification URL: %s" % verify_url)
-
-        result = self._verify_http_request(verify_url, urllib.urlencode({
-            'assertion': assertion,
-            'audience': audience
-        }))
-        if result['status'] == OKAY_RESPONSE:
-            return result
-        log.error("BrowserID verification failure. Response: %r"
-                  " Audience: %r" % (result, audience))
-        log.error("BID assert: %r" % assertion)
-        return False
+    def verify(self, *args):
+        warn('Deprecated, please use the standalone function '
+             'django_browserid.verify instead.', DeprecationWarning)
+        return verify(*args)
 
     def filter_users_by_email(self, email):
         """Return all users matching the specified email."""
@@ -155,9 +54,9 @@ class BrowserIDBackend(object):
         An audience should be in the form ``https://example.com`` or
         ``http://localhost:8001``.
 
-        See django_browserid.auth.get_audience()
+        See django_browserid.base.get_audience()
         """
-        result = self.verify(assertion, audience)
+        result = verify(assertion, audience)
         if result is None:
             return None
         email = result['email']

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -1,0 +1,132 @@
+import logging
+import urllib
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+
+from django.conf import settings
+
+import requests
+
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_HTTP_TIMEOUT = 5
+DEFAULT_VERIFICATION_URL = 'https://browserid.org/verify'
+OKAY_RESPONSE = 'okay'
+
+
+def get_audience(request):
+    """Uses Django settings to format the audience.
+
+    To use this function, make sure there is either a SITE_URL in
+    your settings.py file or PROTOCOL and DOMAIN.
+
+    Examples using SITE_URL:
+        SITE_URL = 'http://127.0.0.1:8001'
+        SITE_URL = 'https://example.com'
+        SITE_URL = 'http://example.com'
+
+    If you don't have a SITE_URL you can also use these varables:
+    PROTOCOL, DOMAIN, and (optionally) PORT.
+    Example 1:
+        PROTOCOL = 'https://'
+        DOMAIN = 'example.com'
+
+    Example 2:
+        PROTOCOL = 'http://'
+        DOMAIN = '127.0.0.1'
+        PORT = '8001'
+
+    If none are set, we trust the request to populate the audience.
+    This is *not secure*!
+    """
+    site_url = getattr(settings, 'SITE_URL', False)
+
+    # Note audience based on request for developer warnings
+    if request.is_secure():
+        req_proto = 'https://'
+    else:
+        req_proto = 'http://'
+    req_domain = request.get_host()
+
+    # If we don't define it explicitly
+    if not site_url:
+        protocol = getattr(settings, 'PROTOCOL', req_proto)
+        if not getattr(settings, 'DOMAIN'):
+            log.warning('django-browserid WARNING you are missing '
+                        'settings.SITE_URL. This is not a secure way '
+                        'to verify assertions. Please fix me. '
+                        'Setting domain to %s.' % req_domain)
+
+        # DOMAIN is example.com req_domain is example.com:8001
+        domain = getattr(settings, 'DOMAIN', req_domain.split(':')[0])
+
+        standards = {'https://': 443, 'http://': 80}
+        if ':' in req_domain:
+            req_port = req_domain.split(':')[1]
+        else:
+            req_port = None
+        port = getattr(settings, 'PORT', req_port or standards[protocol])
+        if port == standards[protocol]:
+            site_url = ''.join(map(str, (protocol, domain)))
+        else:
+            site_url = ''.join(map(str, (protocol, domain, ':', port)))
+
+    req_url = "%s%s" % (req_proto, req_domain)
+    if site_url != "%s%s" % (req_proto, req_domain):
+        log.warning('Misconfigured SITE_URL? settings has [%s], but '
+                    'actual request was [%s] BrowserID may fail on '
+                    'audience' % (site_url, req_url))
+    return site_url
+
+
+def _verify_http_request(url, qs):
+    parameters = {
+        'data': qs,
+        'proxies': getattr(settings, 'BROWSERID_PROXY_INFO', None),
+        'verify': getattr(settings, 'BROWSERID_DISABLE_CERT_CHECK', False),
+        'headers': {'Content-type': 'application/x-www-form-urlencoded'},
+        'params': {
+            'timeout': getattr(settings, 'BROWSERID_HTTP_TIMEOUT',
+                               DEFAULT_HTTP_TIMEOUT)
+        }
+    }
+
+    if not parameters['verify']:
+        parameters['verify'] = getattr(settings, 'BROWSERID_CACERT_FILE', True)
+
+    r = requests.post(url, **parameters)
+
+    try:
+        rv = json.loads(r.content)
+    except ValueError:
+        log.debug('Failed to decode JSON. Resp: %s, Content: %s' %
+                  (r.status_code, r.content))
+        return dict(status='failure')
+
+    return rv
+
+
+def verify(assertion, audience):
+    """Verify assertion using an external verification service."""
+    verify_url = getattr(settings, 'BROWSERID_VERIFICATION_URL',
+                         DEFAULT_VERIFICATION_URL)
+
+    log.info("Verification URL: %s" % verify_url)
+
+    result = _verify_http_request(verify_url, urllib.urlencode({
+        'assertion': assertion,
+        'audience': audience
+    }))
+
+    if result['status'] == OKAY_RESPONSE:
+        return result
+
+    log.error('BrowserID verification failure. Response: %r '
+              'Audience: %r' % (result, audience))
+    log.error("BID assert: %r" % assertion)
+    return False

--- a/django_browserid/tests/test_verification.py
+++ b/django_browserid/tests/test_verification.py
@@ -7,10 +7,12 @@ from contextlib import contextmanager
 from django.conf import settings
 from django.contrib import auth
 
-from django_browserid import auth as browserid_auth
+from django_browserid.base import verify
+
 
 assertion = 'foo.bar.baz'
 audience = 'http://localhost:8000'
+
 
 authenticate_kwargs = {
     'assertion': assertion,
@@ -51,7 +53,7 @@ def test_backend_authenticate(fake):
     auth.authenticate(**authenticate_kwargs)
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend.verify')
+@fudge.patch('django_browserid.auth.verify')
 def test_backend_verify(fake):
     """Test that authenticate() calls verify()."""
     (fake.expects_call()
@@ -60,7 +62,7 @@ def test_backend_verify(fake):
     auth.authenticate(**authenticate_kwargs)
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend._verify_http_request')
+@fudge.patch('django_browserid.base._verify_http_request')
 def test_backend_verify_invalid_assertion(fake):
     """Test that authenticate() returns None when credentials are bad."""
     with negative_assertion(fake):
@@ -68,17 +70,16 @@ def test_backend_verify_invalid_assertion(fake):
         assert user is None
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend._verify_http_request')
+@fudge.patch('django_browserid.base._verify_http_request')
 def test_verify_correct_credentials(fake):
     """Test that verify() returns assertion details when assertion is valid."""
     with positive_assertion(fake):
-        backend = browserid_auth.BrowserIDBackend()
-        verification = backend.verify(assertion, audience)
+        verification = verify(assertion, audience)
         assert verification['status'] == 'okay'
         assert verification['email'] == 'myemail@example.com'
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend._verify_http_request')
+@fudge.patch('django_browserid.base._verify_http_request')
 def test_authenticate_create_user(fake):
     """Test that automatic user creation works when enabled."""
     with positive_assertion(fake):
@@ -93,7 +94,7 @@ def test_authenticate_create_user(fake):
             hashlib.sha1(user.email).digest()).rstrip('=')
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend._verify_http_request')
+@fudge.patch('django_browserid.base._verify_http_request')
 def test_authenticate_create_user_with_alternate_username_algo(fake):
     """Test that automatic user creation with an alternate username algo
     works."""
@@ -110,7 +111,7 @@ def test_authenticate_create_user_with_alternate_username_algo(fake):
         assert user.username == 'myemail'
 
 
-@fudge.patch('django_browserid.auth.BrowserIDBackend._verify_http_request')
+@fudge.patch('django_browserid.base._verify_http_request')
 def test_authenticate_missing_user(fake):
     """Test that authenticate() returns None when user creation disabled."""
     with positive_assertion(fake, email='someotheremail@example.com'):


### PR DESCRIPTION
Also moves verify and get_audience to base.py and makes them
importable from django_browserid directly. Their old references
have been deprecated and will be removed after a reasonable(?)
amount of time.
