### PR TITLE
Deprecate DOMAIN and PROTOCOL in favor of SITE_URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,23 +42,14 @@ Edit your ``urls.py`` file and add the following::
        # ...
    )
 
-You can also set the following config in ``settings.py``::
+You should also add the following in ``settings.py``::
 
     # Note: No trailing slash
-    SITE_URL = 'https://example.com'
+    SITE_URL = 'https://example.com:8000'
 
 BrowserID uses an assertion and an audience to verify the user. This
-``SITE_URL`` is used to determine the audience. If you don't want to use
-SITE_URL or it is being used for another purpose, you can use PROTOCOL and
-DOMAIN, such as::
-
-    PROTOCOL = 'https://'
-    DOMAIN = 'example.com'
-    # Optional
-    PORT = 8001
-
-Either way, for security reasons, it is *very important* to set either SITE_URL
-or DOMAIN.
+``SITE_URL`` is used to determine the audience. For security reasons, it is
+*very important* that you set ``SITE_URL`` correctly.
 
 You can also set the following optional config in ``settings.py``
 (they have sensible defaults): ::

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -1,5 +1,6 @@
 import logging
 import urllib
+from warnings import warn
 try:
     import json
 except ImportError:
@@ -55,15 +56,13 @@ def get_audience(request):
 
     # If we don't define it explicitly
     if not site_url:
-        protocol = getattr(settings, 'PROTOCOL', req_proto)
-        if not getattr(settings, 'DOMAIN'):
-            log.warning('django-browserid WARNING you are missing '
-                        'settings.SITE_URL. This is not a secure way '
-                        'to verify assertions. Please fix me. '
-                        'Setting domain to %s.' % req_domain)
+        warn('Using DOMAIN and PROTOCOL to specify your BrowserID audience is '
+             'deprecated. Please use the SITE_URL setting instead.',
+             DeprecationWarning)
 
         # DOMAIN is example.com req_domain is example.com:8001
         domain = getattr(settings, 'DOMAIN', req_domain.split(':')[0])
+        protocol = getattr(settings, 'PROTOCOL', req_proto)
 
         standards = {'https://': 443, 'http://': 80}
         if ':' in req_domain:


### PR DESCRIPTION
I can't find a good reason to keep around convoluted code to support two methods of determining the site audience when `SITE_URL` works fine. I couldn't find any major use of `SITE_URL` that conflicts with how we use it; everything I found online conforms to what we expect from the setting (and it's a useful piece to have lying around anyway, especially for absolute URLs).

I propose we deprecate DOMAIN and PROTOCOL in favor of SITE_URL, to be removed in a few months.
