### PR TITLE
Include JS file in sdist and install it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test.db
 /dist/
 /django_browserid.egg-info/
 docs/_build
+MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include CHANGELOG.rst
 include LICENSE
 include README.rst
 include requirements.txt
+recursive-include django_browserid/static/browserid *.js

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from distutils.core import setup
 
 setup(
     name='django-browserid',
@@ -7,5 +7,5 @@ setup(
     author="Paul Osman",
     author_email="paul@mozillafoundation.org",
     install_requires="requests==0.9.1",
-    include_package_data=True
+    package_data={"django_browserid": ["static/browserid/*.js"]},
 )


### PR DESCRIPTION
The setup.py file currently doesn't include browserid.js in the tarball generated by `python setup.py sdist`, or install it. 

The setuptools `include_package_data` keyword arg is ineffective without listing the setuptools-git plugin in `setup_requires` (setuptools natively only finds package data in Subversion). Since `setup_requires` plugins cause problems for people installing without a network connection, it's better to just explicitly list the package data using the `package_data` keyword arg.

Due to a bug in distutils in Python versions prior to 2.7, it's also necessary to list that JS file in MANIFEST.in or it may not be included in the sdist.

I've also switched to a plain `from distutils.core import setup` in place of `from setuptools import setup`, since with the removal of `include_package_data` no setuptools-specific features are used anymore.
