### PR TITLE
Include 'django_browserid.tests' in installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='django-browserid',
     version='0.5.1',
-    packages=['django_browserid'],
+    packages=['django_browserid', 'django_browserid.tests'],
     author='Paul Osman, Michael Kelly',
     author_email='mkelly@mozilla.com',
     url='https://github.com/mozilla/django-browserid',


### PR DESCRIPTION
The tests subpackage has helpers that are useful for running tests in
django projects, such as `mock_browserid`.  Include this subpackage in
the distutils script so that it won't be ignored by pip, easy_install,
etc.
