### PR TITLE
Bug 780223 - Fixes for Persona changes

### DIFF
--- a/django_browserid/static/browserid/browserid.js
+++ b/django_browserid/static/browserid/browserid.js
@@ -1,14 +1,41 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* The BrowserID documentation is at
+ * https://developer.mozilla.org/en-US/docs/BrowserID/Quick_Setup
+ */
  $(document).ready(function() {
+    $('.browserid-login').bind('click', function(e) {
+        e.preventDefault();
+        // Triggers BrowserID login dialog.
+        navigator.id.request();
+    };
+
+    $('.browserid-logout').bind('click', function(e) {
+        e.preventDefault();
+        // Clears User Agent BrowserID state
+        navigator.id.logout();
+    };
+
+    // Deprecated (Will be removed)
     $('#browserid').bind('click', function(e) {
         e.preventDefault();
-        navigator.id.getVerifiedEmail(function(assertion) {
+        navigator.id.request();
+    };
+
+    navigator.id.watch(
+        onlogin: function(assertion) {
             if (assertion) {
                 var $e = $('#id_assertion');
                 $e.val(assertion.toString());
                 $e.parent().submit();
+            }
+        },
+
+        onlogout: function() {
+            /* no additional action required, however
+             * callback must be provided to watch()
+             */
             }
         });
     });


### PR DESCRIPTION
Change to use watch() instead of getVerifiedEmail()
- r feedback.
- Note: moving triggers to .class, however keeping the original #browserid trigger as a deprecated method until it can be properly removed from customer code. 
