### PR TITLE
Update URLs to point to login.persona.org only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ django-browserid is a library that integrates BrowserID_ authentication into
 Django_.
 
 .. _Django: http://www.djangoproject.com/
-.. _BrowserID: https://browserid.org/
+.. _BrowserID: https://login.persona.org/
 
 Documentation
 -------------

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 DEFAULT_HTTP_TIMEOUT = 5
-DEFAULT_VERIFICATION_URL = 'https://browserid.org/verify'
+DEFAULT_VERIFICATION_URL = 'https://verifier.login.persona.org/verify'
 OKAY_RESPONSE = 'okay'
 
 

--- a/django_browserid/tests/__init__.py
+++ b/django_browserid/tests/__init__.py
@@ -31,7 +31,7 @@ class mock_browserid(object):
         self.return_value = {
             u'audience': audience,
             u'email': email,
-            u'issuer': u'browserid.org:443',
+            u'issuer': u'login.persona.org:443',
             u'status': u'okay' if email is not None else u'failure',
             u'valid-until': 1311377222765
         }

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -96,10 +96,10 @@ information)::
 This JavaScript file requires jQuery 1.6 or higher.
 
 .. note:: If you don't want to use the static files framework, you'll need to
-   include the ``https://browserid.org/include.js`` file, as well as
+   include the ``https://login.persona.org/include.js`` file, as well as
    JavaScript similar to ``django_browserid/static/browserid/browserid.js``::
 
-      <script src="https://browserid.org/include.js"></script>
+      <script src="https://login.persona.org/include.js"></script>
       <!-- Include JS for browserid_form here. -->
 
 .. note:: If your site uses `Content Security Policy`_, you will have to add
@@ -108,8 +108,8 @@ This JavaScript file requires jQuery 1.6 or higher.
 
    If you're using `django-csp`_, the following settings will work::
 
-      CSP_SCRIPT_SRC = ("'self'", 'https://browserid.org','https://login.persona.org')
-      CSP_FRAME_SRC = ("'self'", 'https://browserid.org','https://login.persona.org')
+      CSP_SCRIPT_SRC = ("'self'", 'https://login.persona.org')
+      CSP_FRAME_SRC = ("'self'", 'https://login.persona.org')
 
 .. _Form Media: https://docs.djangoproject.com/en/1.3/topics/forms/media/
 .. _Managing static files: https://docs.djangoproject.com/en/1.3/howto/static-files/


### PR DESCRIPTION
This will help applications avoid unnecessary browserid.org -> login.persona.org redirects
