### PR TITLE
Fix request timeouts so they work

### DIFF
--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -94,10 +94,8 @@ def _verify_http_request(url, qs):
         'proxies': getattr(settings, 'BROWSERID_PROXY_INFO', None),
         'verify': not getattr(settings, 'BROWSERID_DISABLE_CERT_CHECK', False),
         'headers': {'Content-type': 'application/x-www-form-urlencoded'},
-        'params': {
-            'timeout': getattr(settings, 'BROWSERID_HTTP_TIMEOUT',
-                               DEFAULT_HTTP_TIMEOUT)
-        }
+        'timeout': getattr(settings, 'BROWSERID_HTTP_TIMEOUT',
+                           DEFAULT_HTTP_TIMEOUT),
     }
 
     if parameters['verify']:


### PR DESCRIPTION
The old code was not configuring a timeout
but oddly it was also causing requests to
post to /verify?timeout=5 which became invalid
recently in a change to the Persona server.
