### PR TITLE
Fix #82: Avoid common infinite-login-loop on error.

### DIFF
--- a/django_browserid/static/browserid/browserid.js
+++ b/django_browserid/static/browserid/browserid.js
@@ -40,7 +40,10 @@
 
         navigator.id.watch({
             onlogin: function(assertion) {
-                if (assertion) {
+                // Don't bother if login just failed.
+                if (location.search.indexOf('bid_login_failed=1') !== -1) {
+                    navigator.id.logout();
+                } else if (assertion) {
                     var $e = $('#id_assertion');
                     $e.val(assertion.toString());
                     $e.parent().submit();

--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -62,14 +62,14 @@ def test_get_redirect_failure():
     # Issuing a GET to the verify view redirects to the failure URL.
     response = verify('get', failure_url='/fail')
     assert response.status_code == 302
-    assert response['Location'].endswith('/fail')
+    assert response['Location'].endswith('/fail?bid_login_failed=1')
 
 
 def test_invalid_redirect_failure():
     # Invalid form arguments redirect to the failure URL.
     response = verify('post', failure_url='/fail', blah='asdf')
     assert response.status_code == 302
-    assert response['Location'].endswith('/fail')
+    assert response['Location'].endswith('/fail?bid_login_failed=1')
 
 
 @mock_browserid(None)
@@ -77,7 +77,25 @@ def test_auth_fail_redirect_failure():
     # If authentication fails, redirect to the failure URL.
     response = verify('post', failure_url='/fail', assertion='asdf')
     assert response.status_code == 302
-    assert response['Location'].endswith('/fail')
+    assert response['Location'].endswith('/fail?bid_login_failed=1')
+
+
+@mock_browserid(None)
+def test_auth_fail_url_parameters():
+    # Ensure that bid_login_failed=1 is appended to the failure url.
+    response = verify('post', failure_url='/fail?', assertion='asdf')
+    assert response['Location'].endswith('/fail?bid_login_failed=1')
+
+    response = verify('post', failure_url='/fail?asdf', assertion='asdf')
+    assert response['Location'].endswith('/fail?asdf&bid_login_failed=1')
+
+    response = verify('post', failure_url='/fail?asdf=4', assertion='asdf')
+    assert response['Location'].endswith('/fail?asdf=4&bid_login_failed=1')
+
+    response = verify('post', failure_url='/fail?asdf=4&bid_login_failed=1',
+                      assertion='asdf')
+    assert response['Location'].endswith('/fail?asdf=4&bid_login_failed=1'
+                                         '&bid_login_failed=1')
 
 
 @mock_browserid('test@example.com')

--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -36,7 +36,15 @@ class Verify(BaseFormView):
         """Handle a failed login. Use this to perform complex redirects
         post-login.
         """
-        return redirect(self.get_failure_url())
+        # Append "?bid_login_failed=1" to the URL to notify the JavaScript that
+        # login failed.
+        failure_url = self.get_failure_url()
+
+        if not failure_url.endswith('?'):
+            failure_url += '?' if not '?' in failure_url else '&'
+        failure_url += 'bid_login_failed=1'
+
+        return redirect(failure_url)
 
     def form_valid(self, form):
         """Handles the return post request from the browserID form and puts
@@ -58,7 +66,7 @@ class Verify(BaseFormView):
         return self.login_failure()
 
     def get(self, *args, **kwargs):
-        return redirect(self.get_failure_url())
+        return self.login_failure()
 
     def get_failure_url(self):
         """

--- a/docs/details/troubleshooting.rst
+++ b/docs/details/troubleshooting.rst
@@ -22,6 +22,27 @@ you're using the `django-csp`_ library, the following settings will work::
 .. _django-csp: https://github.com/mozilla/django-csp
 
 
+Site keeps redirecting to the same page repeatedly
+--------------------------------------------------
+
+Sometimes, after attempting to login, you might notice that the page keeps
+reloading itself over and over. This usually means that something has gone wrong
+in your login process, and you should check the log output as well as the
+solutions below to see if they can point you in the right direction.
+
+The reason for the repeating redirects has to do with Persona, the default
+BrowserID server that ``django-browserid`` uses. If you have attempted to log in
+to a site via Persona, and the site fails to accept your login, Persona will
+continue to attempt to log you in if the JavaScript shim that it provides is
+included on the page.
+
+The easiest way to get around this is to simply not include the login form on
+any pages when the user is logged in. ``django-browserid`` attempts to avoid
+these infinite loops in certain cases, but they may still come up if, for
+example, ``SESSION_COOKIE_SECURE`` is True on a development instance without
+SSL.
+
+
 Login fails silently due to SESSION_COOKIE_SECURE
 -------------------------------------------------
 


### PR DESCRIPTION
Avoids a login loop due to login errors and Persona's need to auto-login
users without their explicit action. _shakes fist at Persona_

There's still other situations that may cause infinite loops, but they
shouldn't show up in production and/or have either obvious log entries
or documentation explaining what caused them.
