### PR TITLE
Bug 794634 - Add unverified email addresses from Persona

### DIFF
--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -59,7 +59,7 @@ class BrowserIDBackend(object):
 
         return User.objects.create_user(username, email)
 
-    def authenticate(self, assertion=None, audience=None):
+    def authenticate(self, assertion=None, audience=None, **kw):
         """``django.contrib.auth`` compatible authentication method.
 
         Given a BrowserID assertion and an audience, it attempts to
@@ -71,7 +71,7 @@ class BrowserIDBackend(object):
 
         See django_browserid.base.get_audience()
         """
-        result = verify(assertion, audience)
+        result = verify(assertion, audience, extra_params=kw)
         if not result:
             return None
 

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -115,17 +115,21 @@ def _verify_http_request(url, qs):
     return rv
 
 
-def verify(assertion, audience):
-    """Verify assertion using an external verification service."""
+def verify(assertion, audience, extra_params=None):
+    """Verify assertion using an external verification service.
+       extra_params is a dict of additional parameters to send to the
+        verification service.
+    """
     verify_url = getattr(settings, 'BROWSERID_VERIFICATION_URL',
                          DEFAULT_VERIFICATION_URL)
 
     log.info("Verification URL: %s" % verify_url)
 
-    result = _verify_http_request(verify_url, urllib.urlencode({
-        'assertion': assertion,
-        'audience': audience
-    }))
+    args = {'assertion': assertion,
+            'audience': audience}
+    if extra_params:
+        args.update(extra_params)
+    result = _verify_http_request(verify_url, urllib.urlencode(args))
 
     if result['status'] == OKAY_RESPONSE:
         return result

--- a/django_browserid/tests/test_verification.py
+++ b/django_browserid/tests/test_verification.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.models import User
 
-from mock import patch
+from mock import patch, ANY
 
 from django_browserid.base import verify
 from django_browserid.tests import mock_browserid
@@ -49,7 +49,7 @@ def test_backend_verify(fake):
     """Test that authenticate() calls verify()."""
     fake.return_value = False
     auth.authenticate(**authenticate_kwargs)
-    fake.assert_called_with(assertion, audience)
+    fake.assert_called_with(assertion, audience, extra_params={})
 
 
 @mock_browserid(None)
@@ -114,3 +114,19 @@ def test_authenticate_missing_user():
     """Test that authenticate() returns None when user creation disabled."""
     user = auth.authenticate(**authenticate_kwargs)
     assert user is None
+
+@patch.object(settings, 'BROWSERID_ALLOW_UNVERIFIED', True, create=True)
+@patch.object(settings, 'BROWSERID_VERIFICATION_URL', 'https://unverifier.persona.org/verify', create=True)
+@mock_browserid(return_patcher=True)
+def test_authenticate_unverified_user(patch=None, **kw):
+    """ Test that an unverified email assertion resolves """
+    # in real life, BROWSERID_VERIFICATION_URL would point to the
+    # BID Unverified Email verifier. (Yes, that makes my head hurt too.)
+    args = dict(authenticate_kwargs)
+    patch = patch.__enter__()
+    args['extra_params']={'issuer': 'a.b.c', 'allow_unverified': True}
+
+    user = verify(**args)
+    patch.assert_called_once_with('https://unverifier.persona.org/verify',
+            ANY)
+    assert 'allow_unverified=True' in patch.call_args[0][1]


### PR DESCRIPTION
(See bug 794634#c9 for details)

History:
Several IdPs have stated that they wish to be able to have people able to use some services without having fully validated their email address (e.g. during new user sign ups) The Persona protocol was modified to allow for the optional idea of "unverified addresses" from a given provider. This required light modification of the validation as well as handling the new "unverified-email" field. 
