### PR TITLE
Fix urls.py setup docs. 

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -33,7 +33,7 @@ Edit your ``urls.py`` file and add the following::
 
    urlpatterns = patterns('',
        # ...
-       (r'^browserid/', include('django_browserid.urls')),
+       (r'', include('django_browserid.urls')),
        # ...
    )
 


### PR DESCRIPTION
The way docs explain to include browserid urls.py will result in the following urlpattern

r'^browserid/browserid/verify/' 

This PR fixes the docs.
