### PR TITLE
issue118 - setup.py and inclusion of stuff

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ Patches and Suggestions
 - Paul Mclanahan
 - JR Conlin
 - Prasoon Shukla
+- Peter Bengtsson

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 include CHANGELOG.rst
+include AUTHORS.rst
 include LICENSE
 include README.rst
 include requirements.txt
 recursive-include django_browserid/static/browserid *.js
+recursive-include django_browserid/templates *.html
+recursive-include django_browserid/templatetags *.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 
 with open('README.rst') as file:
@@ -9,11 +9,11 @@ setup(
     description='Django application for adding BrowserID support.',
     long_description=long_description,
     version='0.7.1',
-    packages=['django_browserid', 'django_browserid.tests'],
+    packages=find_packages(),
     author='Paul Osman, Michael Kelly',
     author_email='mkelly@mozilla.com',
     url='https://github.com/mozilla/django-browserid',
     license='MPL v2.0',
     install_requires=['requests>=0.9.1', 'fancy_tag==0.2.0'],
-    package_data={'django_browserid': ['static/browserid/*.js']},
+    include_package_data=True,
 )


### PR DESCRIPTION
@Osmose r?

I actually learned a lot from working on this. It basically boils down to: Don't use distutils, use setuptools. 

When you use distutils you have to list all the packages and you have to maintain both a MANIFEST.in file and you have maintain a `package_data` parameter to `setup()`. 
