### PR TITLE
Allow LOGIN_REDIRECT_URL_FAILURE to be view name

### DIFF
--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -68,8 +68,20 @@ def test_auth_fail_redirect_failure():
 
 
 @mock_browserid(None)
+def test_auth_fail_redirect_view_name_failure():
+    # If authentication fails, redirect to the failure URL which
+    # actually specifies a view name.
+    response = verify('post', failure_url='epic_fail', assertion='asdf')
+    assert response.status_code == 302
+    assert response['Location'].endswith('/epic-fail/?bid_login_failed=1')
+
+
+@mock_browserid(None)
 def test_auth_fail_url_parameters():
     # Ensure that bid_login_failed=1 is appended to the failure url.
+    response = verify('post', failure_url='/fail', assertion='asdf')
+    assert response['Location'].endswith('/fail?bid_login_failed=1')
+
     response = verify('post', failure_url='/fail?', assertion='asdf')
     assert response['Location'].endswith('/fail?bid_login_failed=1')
 

--- a/django_browserid/tests/urls.py
+++ b/django_browserid/tests/urls.py
@@ -1,8 +1,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from django.conf.urls.defaults import include, patterns
+from django.conf.urls.defaults import include, patterns, url
+from django.http import HttpResponse
+
 
 urlpatterns = patterns('',
     (r'^browserid/', include('django_browserid.urls')),
+    url(r'^epic-fail/', lambda r: HttpResponse('this is a stub'),
+        name='epic_fail')
 )


### PR DESCRIPTION
This tweaks the failure_url handling so that it can be a view name
or a url. Also adds a test for it.

Fixes #123.

r?
