### PR TITLE
Fix #97: Raise BrowserIDException on service errors and handle in view.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ History
 Latest
 ++++++
 
+- #97: Add BrowserIDException that is raised by verify when there are issues
+  connecting to the remote verification servie. Update the Verify view to handle
+  these errors.
+
 - #125: Prevent the Verify view from running reverse on user input and add check
   to not redirect to URLs with a different host.
 

--- a/django_browserid/__init__.py
+++ b/django_browserid/__init__.py
@@ -8,4 +8,4 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 __version__ = '0.7.1'
 
 from django_browserid.auth import BrowserIDBackend  # NOQA
-from django_browserid.base import get_audience, verify  # NOQA
+from django_browserid.base import BrowserIDException, get_audience, verify  # NOQA

--- a/django_browserid/tests/test_base.py
+++ b/django_browserid/tests/test_base.py
@@ -5,7 +5,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from django_browserid.base import get_audience
+from mock import patch
+from requests.exceptions import RequestException
+
+from django_browserid.base import BrowserIDException, get_audience, verify
 from django_browserid.tests import patch_settings
 
 
@@ -32,3 +35,16 @@ class TestGetAudience(TestCase):
         # If SITE_URL isn't set, use the domain from the request.
         request = self.factory.post('/', SERVER_NAME='www.blah.com')
         self.assertEqual('http://www.blah.com', get_audience(request))
+
+
+class VerifyTests(TestCase):
+    @patch('django_browserid.base.requests')
+    def test_browserid_exception(self, requests):
+        """
+        If requests.post raises an exception, wrap it in a BrowserIDException.
+        """
+        requests.post.side_effect = RequestException
+        requests.exceptions.RequestException = RequestException
+
+        with self.assertRaises(BrowserIDException):
+            verify('asdf', 'http://testserver/')

--- a/docs/details/api.rst
+++ b/docs/details/api.rst
@@ -34,3 +34,10 @@ Signals
 
 .. automodule:: django_browserid.signals
    :members:
+
+
+Exceptions
+----------
+
+.. autoexception:: django_browserid.base.BrowserIDException
+   :members:


### PR DESCRIPTION
- Adds BrowserIDException and updates verify to raise it when there is 
  an issue connecting to the remote verification service.
- Update the Verify view to catch the raised BrowserIDException and 
  redirect to the login failure page when it is raised.
