### PR TITLE
Issue 138. Fix login failure auto-login

### DIFF
--- a/django_browserid/static/browserid/browserid.js
+++ b/django_browserid/static/browserid/browserid.js
@@ -37,6 +37,7 @@
             onlogin: function(assertion) {
                 // Avoid auto-login on failure.
                 if (loginFailed) {
+                    navigator.id.logout();
                     loginFailed = false;
                     return;
                 }


### PR DESCRIPTION
If you have BROWSERID_CREATE_USER = False, then try to log in with a valid
account on Persona, but not on the site, then you end up in this endless
loop of going to a page on the site and being redirected to the login
failure page immediately.

This fixes that.

Fixes #138
