### PR TITLE
Add a small JS API.

### DIFF
--- a/docs/details/js_api.rst
+++ b/docs/details/js_api.rst
@@ -1,0 +1,32 @@
+JavaScript API
+==============
+
+The JavaScript file that comes with django-browserid, ``browserid.js``,
+includes a a few public functions that are exposed through the
+``django_browserid`` global object.
+
+
+.. js:function:: django_browserid.login([next, requestArgs])
+
+   Manually trigger BrowserID login.
+
+   :param string next: URL to redirect the user to after login.
+   :param object requestArgs: Options to pass to `navigator.id.request`_.
+
+.. _`navigator.id.request`: https://developer.mozilla.org/en-US/docs/DOM/navigator.id.request
+
+
+.. js:function:: django_browserid.logout([next])
+
+   Manually trigger BrowserID logout.
+
+   :param string next: URL to redirect the user to after logout.
+
+
+.. js:function:: django_browserid.isUserAuthenticated()
+
+   Check if the current user has authenticated via django_browserid. Note that
+   this relies on the ``#browserid-info`` element having been loaded into the
+   DOM already. If it hasn't, this will return false.
+
+   :returns: True if the user has authenticated, false otherwise.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ to fork_ and contribute!
    details/settings
    details/troubleshooting
    details/api
+   details/js_api
 
 Developer Guide
 ---------------


### PR DESCRIPTION
Adds a global variable to browserid.js (django_browserid) that has 3
useful methods: login and logout for manually triggering BrowserID,
and isUserAuthenticated for checking if the current user is 
authenticated.

We still need to add some automated testing for the JS, but in the
meantime I've tested this on my test playdoh site and it seemed to
work fine. I'll also be using this on Flicks very soon (guess what
motivated me to add these? :P).
