### PR TITLE
Add support for lazily-evaluated BROWSERID_REQUEST_ARGS.

### DIFF
--- a/django_browserid/helpers.py
+++ b/django_browserid/helpers.py
@@ -10,7 +10,7 @@ from django.utils.safestring import mark_safe
 
 from django_browserid.forms import (BROWSERID_SHIM, BrowserIDForm,
                                     FORM_JAVASCRIPT)
-from django_browserid.util import static_url
+from django_browserid.util import LazyEncoder, static_url
 
 
 # If funfactory is available, we want to use it's locale-aware reverse instead
@@ -28,11 +28,14 @@ def browserid_info(request):
     at the top of the page just below the <body> tag.
     """
     form = BrowserIDForm(auto_id=False)
-    request_args = getattr(settings, 'BROWSERID_REQUEST_ARGS', {})
+
+    # Force request_args to be a dictionary, in case it is lazily generated.
+    request_args = dict(getattr(settings, 'BROWSERID_REQUEST_ARGS', {}))
+
     return render_to_string('browserid/info.html', {
         'email': getattr(request.user, 'email', ''),
         'login_url': reverse('browserid_login'),
-        'request_args': json.dumps(request_args),
+        'request_args': json.dumps(request_args, cls=LazyEncoder),
         'form': form,
     }, RequestContext(request))
 

--- a/django_browserid/tests/test_util.py
+++ b/django_browserid/tests/test_util.py
@@ -1,0 +1,20 @@
+import json
+
+from nose.tools import eq_
+
+from django.test import TestCase
+from django.utils.functional import lazy
+
+from django_browserid.util import LazyEncoder
+
+
+def _lazy_string():
+    return 'blah'
+lazy_string = lazy(_lazy_string, unicode)()
+
+
+class TestLazyEncoder(TestCase):
+    def test_lazy(self):
+        thing = ['foo', lazy_string]
+        thing_json = json.dumps(thing, cls=LazyEncoder)
+        eq_('["foo", "blah"]', thing_json)

--- a/django_browserid/util.py
+++ b/django_browserid/util.py
@@ -1,6 +1,22 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+
+from django.utils.functional import Promise
+from django.utils.encoding import force_unicode
+
+
+class LazyEncoder(json.JSONEncoder):
+    """
+    JSONEncoder that turns Promises into unicode strings to support functions
+    like ugettext_lazy and reverse_lazy.
+    """
+    def default(self, obj):
+        if isinstance(obj, Promise):
+            return force_unicode(obj)
+        return super(LazyEncoder, self).default(obj)
+
 
 # Attempt to use staticfiles_storage.url to retrieve static file URLs.
 # If it can't be found (Django 1.3), default to prepending settings.STATIC_URL
@@ -14,3 +30,4 @@ except ImportError:
     def static_url(path):
         """Return a public URL for the given static file path."""
         return ''.join([settings.STATIC_URL, path])
+

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import codecs
 import os
 import re


### PR DESCRIPTION
Updates our use of BROWSERID_REQUEST_ARGS to support Django Promises.
This is primarily useful for translating strings in the request args
using lazy translation, as well as reversing URLs using reverse_lazy.
