### PR TITLE
Fix #141: Remove email from browserid_info if user authed normally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 MANIFEST
 .DS_Store
 virtualenv/
+*.egg

--- a/django_browserid/helpers.py
+++ b/django_browserid/helpers.py
@@ -33,8 +33,16 @@ def browserid_info(request):
     # Force request_args to be a dictionary, in case it is lazily generated.
     request_args = dict(getattr(settings, 'BROWSERID_REQUEST_ARGS', {}))
 
+    # Only pass an email to the JavaScript if the current user was authed with
+    # our auth backend.
+    backend = getattr(request.user, 'backend', None)
+    if backend == 'django_browserid.auth.BrowserIDBackend':
+        email = getattr(request.user, 'email', '')
+    else:
+        email = ''
+
     return render_to_string('browserid/info.html', {
-        'email': getattr(request.user, 'email', ''),
+        'email': email,
         'login_url': reverse('browserid_login'),
         'request_args': json.dumps(request_args, cls=LazyEncoder),
         'form': form,

--- a/django_browserid/tests/settings.py
+++ b/django_browserid/tests/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = (
 ROOT_URLCONF = 'django_browserid.tests.urls'
 
 AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
     'django_browserid.auth.BrowserIDBackend',
 )
 


### PR DESCRIPTION
If the user authenticates using a different method than BrowserID, the
browserid_info function should not include the user's email for use
by the JavaScript.
