### PR TITLE
Include css in package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include AUTHORS.rst
 include LICENSE
 include README.rst
 include requirements.txt
-recursive-include django_browserid/static/browserid *.js
+recursive-include django_browserid/static/browserid *.js *.css
 recursive-include django_browserid/templates *.html
 recursive-include django_browserid/templatetags *.py


### PR DESCRIPTION
Makes the persona-buttons.css file available when installed using pip.
