### PR TITLE
Ensure backend attribute exists on user objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: DJANGO_VERSION=1.5.1
   allow_failures:
     - python: 3.2
+    - python: 3.3
 install:
   - pip install -e git+git://github.com/sobotklp/django-nose@b3f485e914965e0a7b7012c309864d6a6dcac3ed#egg=django-nose
   - pip install django==${DJANGO_VERSION}

--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -109,7 +109,9 @@ class BrowserIDBackend(object):
 
     def get_user(self, user_id):
         try:
-            return self.User.objects.get(pk=user_id)
+            user = self.User.objects.get(pk=user_id)
+            user.backend = 'django_browserid.auth.BrowserIDBackend'
+            return user
         except self.User.DoesNotExist:
             return None
 

--- a/django_browserid/tests/test_auth.py
+++ b/django_browserid/tests/test_auth.py
@@ -98,6 +98,14 @@ class BrowserIDBackendTests(TestCase):
         self.auth('a@b.com', browserid_extra=dic)
         user_verify.assert_called_with('asdf', 'asdf', extra_params=dic)
 
+    def test_get_user(self):
+        # If a user is retrieved by the BrowserIDBackend, it should have
+        # 'django_browserid.auth.BrowserIDBackend' for the backend attribute.
+        user = new_user('a@example.com')
+        backend = BrowserIDBackend()
+        self.assertEqual(backend.get_user(user.id).backend,
+                         'django_browserid.auth.BrowserIDBackend')
+
 
 if get_user_model:
     # Only run custom user model tests if we're using a version of Django that


### PR DESCRIPTION
A user's email is only included in the browserid_info div if it was
authenticated by the BrowserIDBackend, which is signified by the
backend attribute on the user object. However, if a user is retrieved
from the session, the backend attribute isn't set by default.

In that case, the user object is retrieved by the get_user method
on the backend that first logged the user in. This commit updates that
method so that it sets the backend attribute on the user object, 
ensuring that it will always have that attribute and can be correctly
identified as being authed by the BrowserIDBackend.

Oh, and I also added Python 3.3 to the allowed failures list in Travis
until we figure out why lxml doesn't want to install on it.
