### PR TITLE
Add getAssertion and verifyAssertion to JavaScript API.

### DIFF
--- a/docs/details/js_api.rst
+++ b/docs/details/js_api.rst
@@ -30,3 +30,22 @@ includes a a few public functions that are exposed through the
    DOM already. If it hasn't, this will return false.
 
    :returns: True if the user has authenticated, false otherwise.
+
+
+.. js:function:: django_browserid.getAssertion(callback)
+
+   Retrieve an assertion from BrowserID and execute the given callback with the
+   assertion as the single argument.
+
+   :param function callback: Callback to execute after the assertion has been
+                             retrieved.
+
+
+.. js:function:: django_browserid.verifyAssertion(assertion, [redirectTo])
+
+   Verify an assertion, and redirect to a URL on success. Calling this method
+   submits a form to the server and changes the current page as if the user
+   was attempting to login.
+
+   :param string assertion: Assertion to verify.
+   :param string redirectTo: URL to redirect to on success.


### PR DESCRIPTION
On Flicks, we ran into an issue where we wanted to perform an action that required a POST and a csrf token and prompt the user for login first if they aren't logged in. The problem is that if we attempt to log the user in prior to performing the action, django-browserid will redirect the user to a new page. If that new page automatically does the action, it will be vulnerable to a CSRF attack.

The alternative was to perform the action, store the intent in the user's session, and then prompt them for login, and perform the action post-login if the intent is found in their session. The issue with this is that the action requires an AJAX request, and calling the login code from within the AJAX handler causes popup warnings because navigator.id.request is being called outside of a click handler.

The next option was to use navigator.id.get to get an assertion, and then perform the action, and lastly submit the assertion for verification once the action was logged in their session. This would've worked, except include.js doesn't allow you to use navigator.id.get at the same time as navigator.id.watch.

Thus, this patch. It emulates the functionality of navigator.id.get using the watch API, and also adds a function to trigger the verification form submission in case anyone wants to trigger login from within the callback. 

Long term I think we should change verifyAssertion to use an iframe so that we can finally support verification and login without leaving the page, but this should work in the short term and let me get on with my Flicks work. :D
