### PR TITLE
Fix #194: Replace verify function with Verifier classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 virtualenv/
 *.egg
 .tox
+tmp

--- a/django_browserid/__init__.py
+++ b/django_browserid/__init__.py
@@ -8,4 +8,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 __version__ = '0.9'
 
 from django_browserid.auth import BrowserIDBackend  # NOQA
-from django_browserid.base import BrowserIDException, get_audience, verify  # NOQA
+from django_browserid.base import (
+    BrowserIDException,
+    get_audience,
+    RemoteVerifier,
+    VerificationResult
+)  # NOQA

--- a/django_browserid/auth.py
+++ b/django_browserid/auth.py
@@ -6,16 +6,15 @@ import hashlib
 import logging
 
 from django.conf import settings
-from django.db import IntegrityError
 
 try:
     from django.utils.encoding import smart_bytes
 except ImportError:
     from django.utils.encoding import smart_str as smart_bytes
 
-from django_browserid.base import verify
+from django_browserid.base import get_audience, RemoteVerifier
 from django_browserid.signals import user_created
-from django_browserid.util import import_function_from_setting
+from django_browserid.util import import_from_setting
 
 try:
     from django.contrib.auth import get_user_model
@@ -44,12 +43,16 @@ class BrowserIDBackend(object):
     supports_object_permissions = False
 
     def __init__(self):
-        """
-        Store the current user model on creation to avoid issues if
-        settings.AUTH_USER_MODEL changes, which usually only happens during
-        tests.
-        """
+        # Store the current user model on creation to avoid issues if settings.AUTH_USER_MODEL
+        # changes, which usually only happens during tests.
         self.User = get_user_model()
+
+    def get_verifier(self):
+        """
+        Create a verifier for verifying assertions. Uses a
+        :class:`django_browserid.base.RemoteVerifier` by default.
+        """
+        return RemoteVerifier()
 
     def filter_users_by_email(self, email):
         """Return all users matching the specified email."""
@@ -57,6 +60,8 @@ class BrowserIDBackend(object):
 
     def create_user(self, email):
         """Return object for a newly created user account."""
+        from django.db import IntegrityError  # Importing at the top causes issues on DB init.
+
         username_algo = getattr(settings, 'BROWSERID_USERNAME_ALGO', None)
         if username_algo is not None:
             username = username_algo(email)
@@ -80,23 +85,44 @@ class BrowserIDBackend(object):
         # This method is basically for your overriding pleasures.
         return True
 
-    def authenticate(self, assertion=None, audience=None, browserid_extra=None, **kw):
-        """``django.contrib.auth`` compatible authentication method.
-
-        Given a BrowserID assertion and an audience, it attempts to
-        verify them and then extract the email address for the authenticated
-        user.
-
-        An audience should be in the form ``https://example.com`` or
-        ``http://localhost:8001``.
-
-        See django_browserid.base.get_audience()
+    def authenticate(self, assertion=None, audience=None, request=None, **kwargs):
         """
-        result = verify(assertion, audience, extra_params=browserid_extra)
+        Authenticate a user by verifying a BrowserID assertion. Defers to the verifier returned by
+        :func:`BrowserIDBackend.get_verifier` for verification.
+
+        You may either pass the ``request`` parameter to determine the audience from the request,
+        or pass the ``audience`` parameter explicitly.
+
+        :param assertion:
+            Assertion submitted by the user. This asserts that the user controls a specific email
+            address.
+
+        :param audience:
+            The audience to use when verifying the assertion; this prevents another site using
+            an assertion for their site to login to yours. This value takes precedence over the
+            audience pulled from the request parameter, if given.
+
+        :param request:
+            The request that generated this authentication attempt. This is used to determine the
+            audience to use during verification, using the
+            :func:`django_browserid.base.get_audience` function. If the audience parameter is also
+            passed, it will be used instead of the audience from the request.
+
+        :param kwargs:
+            All remaining keyword arguments are passed to the ``verify`` function on the verifier.
+        """
+        if audience is None and request:
+            audience = get_audience(request)
+
+        if audience is None or assertion is None:
+            return None
+
+        verifier = self.get_verifier()
+        result = verifier.verify(assertion, audience, **kwargs)
         if not result:
             return None
 
-        email = result['email']
+        email = result.email
         if not self.is_valid_email(email):
             return None
 
@@ -119,7 +145,7 @@ class BrowserIDBackend(object):
                 create_function = self.create_user
             else:
                 # Find the function to call.
-                create_function = import_function_from_setting('BROWSERID_CREATE_USER')
+                create_function = import_from_setting('BROWSERID_CREATE_USER')
 
             user = create_function(email)
             user_created.send(create_function, user=user)

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -3,9 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
 import logging
+from datetime import datetime
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.http import same_origin
 
 import requests
 
@@ -13,161 +15,14 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_HTTP_TIMEOUT = 5
-DEFAULT_VERIFICATION_URL = 'https://verifier.login.persona.org/verify'
-DEFAULT_PROXY_INFO = None
-DEFAULT_DISABLE_CERT_CHECK = False
-DEFAULT_HEADERS = {'Content-type': 'application/x-www-form-urlencoded'}
-
-
 class BrowserIDException(Exception):
-    """
-    Raised when there is an issue verifying an assertion with
-    :func:`django_browserid.base.verify`.
-    """
+    """Raised when there is an issue verifying an assertion."""
     def __init__(self, exc):
         #: Original exception that caused this to be raised.
         self.exc = exc
 
     def __unicode__(self):
         return unicode(self.exc)
-
-
-def get_audience(request):
-    """
-    Uses Django settings to format the audience.
-
-    To figure out the audience to use, it does this:
-
-    1. If settings.DEBUG is True and settings.SITE_URL is not set or
-       empty, then the domain on the request will be used.
-
-       This is *not* secure!
-
-    2. Otherwise, settings.SITE_URL is checked for the request
-       domain and an ImproperlyConfigured error is raised if it
-       is not found.
-
-    Examples of settings.SITE_URL::
-
-        SITE_URL = 'http://127.0.0.1:8001'
-        SITE_URL = 'https://example.com'
-        SITE_URL = 'http://example.com'
-        SITE_URL = (
-            'http://127.0.0.1:8001',
-            'https://example.com',
-            'http://example.com'
-        )
-
-    """
-    req_proto = 'https://' if request.is_secure() else 'http://'
-    req_domain = request.get_host()
-    req_url = '%s%s' % (req_proto, req_domain)
-    site_url = getattr(settings, 'SITE_URL', None)
-    if not site_url:
-        if settings.DEBUG:
-            return req_url
-        else:
-            raise ImproperlyConfigured('`SITE_URL` must be set. See '
-                                       'documentation for django-browserid')
-    if isinstance(site_url, basestring):
-        site_url = [site_url]
-    try:
-        url_iterator = iter(site_url)
-    except TypeError:
-        raise ImproperlyConfigured('`SITE_URL` is not a string or an iterable')
-    if req_url not in url_iterator:
-        raise ImproperlyConfigured('request `{0}`, was not found in SITE_URL `{1}`'
-                                   .format(req_url, site_url))
-    return req_url
-
-
-def _verify_http_request(url, data):
-    parameters = {
-        'data': data,
-        'proxies': getattr(settings, 'BROWSERID_PROXY_INFO',
-                           DEFAULT_PROXY_INFO),
-        'verify': not getattr(settings, 'BROWSERID_DISABLE_CERT_CHECK',
-                              DEFAULT_DISABLE_CERT_CHECK),
-        'headers': DEFAULT_HEADERS,
-        'timeout': getattr(settings, 'BROWSERID_HTTP_TIMEOUT',
-                           DEFAULT_HTTP_TIMEOUT),
-    }
-
-    if parameters['verify']:
-        parameters['verify'] = getattr(settings, 'BROWSERID_CACERT_FILE', True)
-
-    try:
-        r = requests.post(url, **parameters)
-    except requests.exceptions.RequestException as e:
-        raise BrowserIDException(e)
-
-    try:
-        rv = json.loads(r.content)
-    except (ValueError, TypeError):
-        logger.warning('Failed to decode JSON. Resp: %s, Content: %s',
-                       r.status_code, r.content)
-        return dict(status='failure')
-
-    return rv
-
-
-def verify(assertion, audience, extra_params=None, url=None):
-    """
-    Verify assertion using an external verification service.
-
-    :param assertion:
-        The string assertion received in the client from
-        ``navigator.id.request()``.
-    :param audience:
-        This is domain of your website and it must match what
-        was in the URL bar when the client asked for an assertion.
-        You probably want to use
-        :func:`django_browserid.get_audience` which sets it
-        based on ``SITE_URL``.
-    :param extra_params:
-        A dict of additional parameters to send to the
-        verification service as part of the POST request.
-    :param url:
-        A custom verification URL for the service.
-        The service URL can also be set using the
-        ``BROWSERID_VERIFICATION_URL`` setting.
-
-    :returns:
-        A dictionary similar to the following:
-
-        .. code-block:: python
-
-           {
-               u'audience': u'https://mysite.com:443',
-               u'email': u'myemail@example.com',
-               u'issuer': u'browserid.org',
-               u'status': u'okay',
-               u'expires': 1311377222765
-           }
-
-    :raises: BrowserIDException: Error connecting to remote verification
-        service.
-    """
-    if not url:
-        url = getattr(settings, 'BROWSERID_VERIFICATION_URL',
-                      DEFAULT_VERIFICATION_URL)
-
-    logger.info('Verification URL: %s', url)
-
-    args = {'assertion': assertion, 'audience': audience}
-    if extra_params:
-        args.update(extra_params)
-
-    result = _verify_http_request(url, args)
-
-    if result['status'] != 'okay':
-        logger.warning('BrowserID verification failure. Response: %s '
-                       'Audience: %s', result, audience)
-        logger.warning('BID assert: %s', assertion)
-        return False
-    else:
-        return result
 
 
 def sanity_checks(request):
@@ -195,3 +50,176 @@ def sanity_checks(request):
                            'your CSP policies. Consider adding it to '
                            'CSP_SCRIPT_SRC and CSP_FRAME_SRC',
                            persona)
+
+
+def get_audience(request):
+    """
+    Determine the audience to use for verification from the given request.
+
+    Relies on the BROWSERID_AUDIENCES setting, which is an explicit list of acceptable
+    audiences for your site.
+
+    :returns:
+        The first audience in BROWSERID_AUDIENCES that has the same origin as the request's
+        URL.
+
+    :raises:
+        :class:`django.core.exceptions.ImproperlyConfigured`: If BROWSERID_AUDIENCES isn't
+        defined, or if no matching audience could be found.
+    """
+    try:
+        audiences = settings.BROWSERID_AUDIENCES
+    except AttributeError:
+        raise ImproperlyConfigured('Required setting BROWSERID_AUDIENCES not found!')
+
+    protocol = 'https' if request.is_secure() else 'http'
+    host = '{0}://{1}'.format(protocol, request.get_host())
+    for audience in audiences:
+        if same_origin(host, audience):
+            return audience
+
+    # No audience found? We must not be configured properly, otherwise why are we getting this
+    # request?
+    raise ImproperlyConfigured('No audience could be found in BROWSERID_AUDIENCES for host `{0}`.'
+                               .format(host))
+
+
+class VerificationResult(object):
+    """
+    Result of an attempt to verify an assertion.
+
+    VerificationResult objects can be treated as booleans to test if the verification succeeded or
+    not.
+
+    The fields returned by the remote verification service, such as ``email`` or ``issuer``, are
+    available as attributes if they were included in the response. For example, a failure result
+    will raise an AttributeError if you try to access the ``email`` attribute.
+    """
+    def __init__(self, response):
+        """
+        :param response:
+            Dictionary of the response from the remote verification service.
+        """
+        self._response = response
+
+    def __getattr__(self, name):
+        if name in self._response:
+            return self._response[name]
+        else:
+            raise AttributeError
+
+    @property
+    def expires(self):
+        """The expiration date of the assertion as a naive :class:`datetime.datetime` in UTC."""
+        try:
+            return datetime.utcfromtimestamp(int(self._response['expires']) / 1000.0)
+        except KeyError:
+            raise AttributeError
+        except ValueError:
+            timestamp = self._response['expires']
+            logger.warning('Could not parse expires timestamp: `{0}`'.format(timestamp))
+            return timestamp
+
+    def __nonzero__(self):
+        return self._response.get('status') == 'okay'
+
+    def __unicode__(self):
+        result = u'Success' if self else u'Failure'
+        email = getattr(self, 'email', None)
+        email_string = u' email={0}'.format(email) if email else u''
+        return u'<VerificationResult {0}{1}>'.format(result, email_string)
+
+
+class RemoteVerifier(object):
+    """
+    Verifies BrowserID assertions using a remote verification service.
+
+    By default, this uses the Mozilla Persona service for remote verification.
+    """
+    verification_service_url = 'https://verifier.login.persona.org/verify'
+    requests_parameters = {
+        'timeout': 5
+    }
+
+    def verify(self, assertion, audience, **kwargs):
+        """
+        Verify an assertion using a remote verification service.
+
+        :param assertion:
+            BrowserID assertion to verify.
+
+        :param audience:
+            The protocol, hostname and port of your website. Used to confirm that the assertion was
+            meant for your site and not for another site.
+
+        :param kwargs:
+            Extra keyword arguments are passed on to requests.post to allow customization.
+
+        :returns:
+            :class:`.VerificationResult`
+
+        :raises:
+            :class:`.BrowserIDException`: Error connecting to the remote verification service, or
+            error parsing the response received from the service.
+        """
+        parameters = dict(self.requests_parameters, **{
+            'data': {
+                'assertion': assertion,
+                'audience': audience,
+            }
+        })
+        parameters['data'].update(kwargs)
+
+        try:
+            response = requests.post(self.verification_service_url, **parameters)
+        except requests.exceptions.RequestException as err:
+            raise BrowserIDException(err)
+
+        try:
+            return VerificationResult(json.loads(response.content))
+        except (ValueError, TypeError) as err:
+            # If the returned JSON is invalid, log a warning and return a failure result.
+            logger.warning('Failed to parse remote verifier response: `{0}`'
+                           .format(response.content))
+            return VerificationResult({
+                'status': 'failure',
+                'reason': 'Could not parse verifier response: {0}'.format(err)
+            })
+
+
+class MockVerifier(object):
+    """Mock-verifies BrowserID assertions."""
+
+    def __init__(self, email, **kwargs):
+        """
+        :param email:
+            Email address to include in successful verification result. If None, verify will return
+            a failure result.
+
+        :param kwargs:
+            Extra keyword arguments are used to update successful verification results. This allows
+            for mocking attributes on the result, such as the issuer.
+        """
+        self.email = email
+        self.result_attributes = kwargs
+
+    def verify(self, assertion, audience, **kwargs):
+        """
+        Mock-verify an assertion. The return value is determined by the parameters given to the
+        constructor.
+        """
+        if not self.email:
+            return VerificationResult({
+                'status': 'failure',
+                'reason': 'No email given to MockVerifier.'
+            })
+        else:
+            result = {
+                'status': 'okay',
+                'audience': audience,
+                'email': self.email,
+                'issuer': 'mockissuer.example.com:443',
+                'expires': '1311377222765'
+            }
+            result.update(self.result_attributes)
+            return VerificationResult(result)

--- a/django_browserid/tests/settings.py
+++ b/django_browserid/tests/settings.py
@@ -33,3 +33,5 @@ BROWSERID_CREATE_USER = True
 BROWSERID_USERNAME_ALGO = None
 
 STATIC_URL = 'static/'
+
+BROWSERID_AUDIENCES = ['http://testserver']

--- a/django_browserid/tests/test_auth.py
+++ b/django_browserid/tests/test_auth.py
@@ -8,7 +8,8 @@ from django.test import TestCase
 
 from mock import ANY, Mock, patch
 
-from django_browserid.auth import BrowserIDBackend, default_username_algo, verify
+from django_browserid.auth import BrowserIDBackend, default_username_algo
+from django_browserid.base import MockVerifier
 from django_browserid.tests import mock_browserid
 
 try:
@@ -26,7 +27,7 @@ def new_user(email, username=None):
 
 
 class BrowserIDBackendTests(TestCase):
-    def auth(self, verified_email=None, browserid_extra=None):
+    def auth(self, verified_email=None, **kwargs):
         """
         Attempt to authenticate a user with BrowserIDBackend.
 
@@ -35,7 +36,7 @@ class BrowserIDBackendTests(TestCase):
         """
         with mock_browserid(verified_email):
             backend = BrowserIDBackend()
-            return backend.authenticate(assertion='asdf', audience='asdf', browserid_extra=browserid_extra)
+            return backend.authenticate(assertion='asdf', audience='asdf', **kwargs)
 
     def test_failed_verification(self):
         # If verification fails, return None.
@@ -93,11 +94,14 @@ class BrowserIDBackendTests(TestCase):
         user = self.auth('a@b.com')
         user_created.send.assert_called_with(ANY, user=user)
 
-    @patch('django_browserid.auth.verify', wraps=verify)
-    def test_verify_called_with_browserid_extra(self, user_verify):
-        dic = {'a': 'AlphaA'}
-        self.auth('a@b.com', browserid_extra=dic)
-        user_verify.assert_called_with('asdf', 'asdf', extra_params=dic)
+    def test_verify_called_with_extra_kwargs(self):
+        backend = BrowserIDBackend()
+        verifier = MockVerifier('a@example.com')
+        verifier.verify = Mock(wraps=verifier.verify)
+        backend.get_verifier = lambda: verifier
+
+        backend.authenticate(assertion='asdf', audience='http://testserver', foo='bar')
+        verifier.verify.assert_called_with('asdf', 'http://testserver', foo='bar')
 
     def test_get_user(self):
         # If a user is retrieved by the BrowserIDBackend, it should have

--- a/django_browserid/tests/test_base.py
+++ b/django_browserid/tests/test_base.py
@@ -1,14 +1,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from datetime import datetime
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from mock import ANY, patch
-from requests.exceptions import RequestException
+import requests
+from mock import Mock, patch, PropertyMock
+from nose.tools import eq_, ok_
 
-from django_browserid.base import BrowserIDException, get_audience, verify
+from django_browserid.base import (BrowserIDException, get_audience, MockVerifier, RemoteVerifier,
+                                   VerificationResult)
 from django_browserid.tests import patch_settings
 
 
@@ -16,129 +20,173 @@ class GetAudienceTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    @patch_settings(SITE_URL='http://example.com')
-    def test_improperly_configured(self):
-        # Raise ImproperlyConfigured if SITE_URL doesn't match the request's
-        # URL.
-        request = self.factory.post('/', SERVER_NAME='www.blah.com')
-        with self.assertRaises(ImproperlyConfigured):
-            get_audience(request)
+    def test_setting_missing(self):
+        # If BROWSERID_AUDIENCES isn't defined, raise ImproperlyConfigured.
+        request = self.factory.get('/')
 
-    @patch_settings(SITE_URL='http://example.com')
-    def test_properly_configured(self):
-        # Return SITE_URL if it matches the request URL and DEBUG = True.
-        request = self.factory.post('/', SERVER_NAME='example.com')
-        self.assertEqual('http://example.com', get_audience(request))
+        # Simulate missing attribute with a mock property that raises AttributeError.
+        with patch('django_browserid.base.settings') as settings:
+            mock_browserid_audiences = PropertyMock(side_effect=AttributeError)
+            type(settings).BROWSERID_AUDIENCES = mock_browserid_audiences
 
-    @patch_settings(SITE_URL=['http://example1.com', 'http://example2.com'])
-    def test_iterable(self):
-        # Return correct url from iterable SITE_URL, if it contains request URL.
-        request = self.factory.post('/', SERVER_NAME='example2.com')
-        self.assertEqual('http://example2.com', get_audience(request))
+            with self.assertRaises(ImproperlyConfigured):
+                get_audience(request)
 
-    @patch_settings(DEBUG=True)
-    def test_no_site_url(self):
-        # If SITE_URL isn't set, use the domain from the request.
-        request = self.factory.post('/', SERVER_NAME='www.blah.com')
-        self.assertEqual('http://www.blah.com', get_audience(request))
+    def test_same_origin_found(self):
+        # If an audience is found in BROWSERID_AUDIENCES with the same origin as the request URI,
+        # return it.
+        request = self.factory.get('http://testserver')
+
+        audiences = ['https://example.com', 'http://testserver']
+        with patch_settings(BROWSERID_AUDIENCES=audiences):
+            eq_(get_audience(request), 'http://testserver')
+
+    def test_no_audience(self):
+        # If no matching audiences is found in BROWSERID_AUDIENCES, raise ImproperlyConfigured.
+        request = self.factory.get('http://testserver')
+
+        with patch_settings(BROWSERID_AUDIENCES=['https://example.com']):
+            with self.assertRaises(ImproperlyConfigured):
+                get_audience(request)
 
 
-class VerifyTests(TestCase):
-    def setUp(self):
-        self.post_patcher = patch('django_browserid.base.requests.post')
-        self.post = self.post_patcher.start()
+class VerificationResultTests(TestCase):
+    def test_getattr_attribute_exists(self):
+        # If a value exists in the response dict, it should be an attribute on the result.
+        result = VerificationResult({'myattr': 'foo'})
+        eq_(result.myattr, 'foo')
 
-    def tearDown(self):
-        self.post_patcher.stop()
+    def test_getattr_attribute_doesnt_exist(self):
+        # If a value doesn't exist in the response dict, accessing it as an attribute should raise
+        # an AttributeError.
+        result = VerificationResult({'myattr': 'foo'})
+        with self.assertRaises(AttributeError):
+            result.bar
 
-    @patch('django_browserid.base.DEFAULT_HTTP_TIMEOUT', 5)
-    @patch('django_browserid.base.DEFAULT_VERIFICATION_URL',
-           'https://example.com')
-    @patch('django_browserid.base.DEFAULT_PROXY_INFO', None)
-    @patch('django_browserid.base.DEFAULT_DISABLE_CERT_CHECK', False)
-    @patch('django_browserid.base.DEFAULT_HEADERS', {'Foo': 'Bar'})
-    def test_basic_success(self):
-        self.post.return_value.content = """
-            {"status": "okay", "email": "a@example.com"}
-        """
-        result = verify('asdf', 'http://testserver/')
+    def test_expires_no_attribute(self):
+        # If no expires attribute was in the response, raise an AttributeError.
+        result = VerificationResult({'myattr': 'foo'})
+        with self.assertRaises(AttributeError):
+            result.expires
 
-        self.assertEqual(result, {'status': 'okay', 'email': 'a@example.com'})
-        self.post.assert_called_with(
-            'https://example.com',
-            data={'assertion': 'asdf', 'audience': 'http://testserver/'},
-            proxies=None,
-            verify=True,
-            headers={'Foo': 'Bar'},
-            timeout=5
-        )
+    def test_expires_invalid_timestamp(self):
+        # If the expires attribute cannot be parsed as a timestamp, return the raw string instead.
+        result = VerificationResult({'expires': 'foasdfhas'})
+        eq_(result.expires, 'foasdfhas')
 
-    @patch_settings(
-        BROWSERID_VERIFICATION_URL='http://example.org',
-        BROWSERID_PROXY_INFO={'http': 'http://blah.example.com'},
-        BROWSERID_DISABLE_CERT_CHECK=True,
-        BROWSERID_HTTP_TIMEOUT=10
-    )
-    def test_custom_settings(self):
-        verify('asdf', 'http://testserver/')
-        self.post.assert_called_with(
-            'http://example.org',
-            data={'assertion': 'asdf', 'audience': 'http://testserver/'},
-            proxies={'http': 'http://blah.example.com'},
-            verify=False,
-            headers=ANY,
-            timeout=10
-        )
+    def test_expires_valid_timestamp(self):
+        # If expires contains a valid millisecond timestamp, return a corresponding datetime.
+        result = VerificationResult({'expires': '1379307128000'})
+        eq_(datetime(2013, 9, 16, 4, 52, 8), result.expires)
 
-    def test_custom_url(self):
-        # If a custom URL is passed into verify, send the verification request
-        # to that URL.
-        verify('asdf', 'http://testserver/', url='https://example.com')
-        self.post.assert_called_with(
-            'https://example.com', data=ANY, proxies=ANY, verify=ANY,
-            headers=ANY, timeout=ANY)
+    def test_nonzero_failure(self):
+        # If the response status is not 'okay', the result should be falsy.
+        ok_(not VerificationResult({'status': 'failure'}))
 
-    def test_extra_params(self):
-        # If extra params are passed into verify, they should be included with
-        # the other POST arguments in the verification tests.
-        verify('asdf', 'http://testserver/', extra_params={'a': 'b', 'c': 'd'})
-        expected_data = {
-            'assertion': 'asdf',
-            'audience': 'http://testserver/',
-            'a': 'b',
-            'c': 'd'
-        }
-        self.post.assert_called_with(
-            ANY, data=expected_data, proxies=ANY, verify=ANY, headers=ANY,
-            timeout=ANY)
+    def test_nonzero_okay(self):
+        # If the response status is 'okay', the result should be truthy.
+        ok_(VerificationResult({'status': 'okay'}))
 
-    @patch_settings(
-        BROWSERID_DISABLE_CERT_CHECK=False,
-        BROWSERID_CACERT_FILE='http://testserver/path/to/file'
-    )
-    def test_cacert_file(self):
-        # If certificate verification is enabled and BROWSERID_CACERT_FILE is
-        # set, the path to that file should be passed to requests in the
-        # 'verify' kwarg.
-        verify('asdf', 'http://testserver/')
-        self.post.assert_called_with(
-            ANY, data=ANY, proxies=ANY,
-            verify='http://testserver/path/to/file', headers=ANY, timeout=ANY)
+    def test_unicode_success(self):
+        # If the result is successful, include 'Success' and the email in the string.
+        result = VerificationResult({'status': 'okay', 'email': 'a@example.com'})
+        eq_(unicode(result), u'<VerificationResult Success email=a@example.com>')
 
-    def test_browserid_exception(self):
-        # If requests.post raises an exception, wrap it in BrowserIDException.
-        self.post.side_effect = RequestException
-        with self.assertRaises(BrowserIDException):
-            verify('asdf', 'http://testserver/')
+        # If the email is missing, don't include it.
+        result = VerificationResult({'status': 'okay'})
+        eq_(unicode(result), u'<VerificationResult Success>')
 
-    def test_invalid_json(self):
-        # If the JSON returned by the verification server is invalid, return
-        # False.
-        self.post.return_value.content = '{invalid-json}'
-        self.assertEqual(verify('asdf', 'http://testserver/'), False)
+    def test_unicode_failure(self):
+        # If the result is a failure, include 'Failure' in the string.
+        result = VerificationResult({'status': 'failure'})
+        eq_(unicode(result), u'<VerificationResult Failure>')
 
-    def test_valid_json_failure(self):
-        # If the verification request returns valid json with a status that
-        # isn't 'okay', return False.
-        self.post.return_value.content = '{"status": "failure"}'
-        self.assertEqual(verify('asdf', 'http://testserver/'), False)
+
+class RemoteVerifierTests(TestCase):
+    def _response(self, **kwargs):
+        return Mock(spec=requests.Response, **kwargs)
+
+    def test_verify_requests_parameters(self):
+        # If a subclass overrides requests_parameters, the parameters should be passed to
+        # requests.post.
+        class MyVerifier(RemoteVerifier):
+            requests_parameters = {'foo': 'bar'}
+        verifier = MyVerifier()
+
+        with patch('django_browserid.base.requests.post') as post:
+            post.return_value = self._response(content='{"status":"failure"}')
+            verifier.verify('asdf', 'http://testserver')
+
+        # foo parameter passed with 'bar' value.
+        eq_(post.call_args[1]['foo'], 'bar')
+
+    def test_verify_kwargs(self):
+        # Any keyword arguments passed to verify should be passed on as POST arguments.
+        verifier = RemoteVerifier()
+
+        with patch('django_browserid.base.requests.post') as post:
+            post.return_value = self._response(content='{"status":"failure"}')
+            verifier.verify('asdf', 'http://testserver', foo='bar', baz=5)
+
+        # foo parameter passed with 'bar' value.
+        eq_(post.call_args[1]['data']['foo'], 'bar')
+        eq_(post.call_args[1]['data']['baz'], 5)
+
+    def test_verify_request_exception(self):
+        # If a RequestException is raised during the POST, raise a BrowserIDException with the
+        # RequestException as the cause.
+        verifier = RemoteVerifier()
+        request_exception = requests.exceptions.RequestException()
+
+        with patch('django_browserid.base.requests.post') as post:
+            post.side_effect = request_exception
+            with self.assertRaises(BrowserIDException) as cm:
+                verifier.verify('asdf', 'http://testserver')
+
+        eq_(cm.exception.exc, request_exception)
+
+    def test_verify_invalid_json(self):
+        # If the response contains invalid JSON, return a failure result.
+        verifier = RemoteVerifier()
+
+        with patch('django_browserid.base.requests.post') as post:
+            post.return_value = self._response(content='{asg9=3{{{}}{')
+            result = verifier.verify('asdf', 'http://testserver')
+        ok_(not result)
+        ok_(result.reason.startswith('Could not parse verifier response'))
+
+
+    def test_verify_success(self):
+        # If the response contains valid JSON, return a result object for that response.
+        verifier = RemoteVerifier()
+
+        with patch('django_browserid.base.requests.post') as post:
+            post.return_value = self._response(
+                content='{"status": "okay", "email": "foo@example.com"}')
+            result = verifier.verify('asdf', 'http://testserver')
+        ok_(result)
+        eq_(result.email, 'foo@example.com')
+
+
+class MockVerifierTests(TestCase):
+    def test_verify_no_email(self):
+        # If the given email is None, verify should return a failure result.
+        verifier = MockVerifier(None)
+        result = verifier.verify('asdf', 'http://testserver')
+        ok_(not result)
+        eq_(result.reason, 'No email given to MockVerifier.')
+
+    def test_verify_email(self):
+        # If an email is given to the constructor, return a successful result.
+        verifier = MockVerifier('a@example.com')
+        result = verifier.verify('asdf', 'http://testserver')
+        ok_(result)
+        eq_(result.audience, 'http://testserver')
+        eq_(result.email, 'a@example.com')
+
+    def test_verify_result_attributes(self):
+        # Extra kwargs to the constructor are added to the result.
+        verifier = MockVerifier('a@example.com', foo='bar', baz=5)
+        result = verifier.verify('asdf', 'http://testserver')
+        eq_(result.foo, 'bar')
+        eq_(result.baz, 5)

--- a/django_browserid/tests/test_util.py
+++ b/django_browserid/tests/test_util.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.utils.functional import lazy
 
 from django_browserid.tests import patch_settings
-from django_browserid.util import import_function_from_setting, LazyEncoder
+from django_browserid.util import import_from_setting, LazyEncoder
 
 
 def _lazy_string():
@@ -23,17 +23,17 @@ class TestLazyEncoder(TestCase):
         eq_('["foo", "blah"]', thing_json)
 
 
-class ImportFunctionFromSettingTests(TestCase):
+class ImportFromSettingTests(TestCase):
     def test_no_setting(self):
         """If the setting doesn't exist, raise ImproperlyConfigured."""
         with self.assertRaises(ImproperlyConfigured):
-            import_function_from_setting('DOES_NOT_EXIST')
+            import_from_setting('DOES_NOT_EXIST')
 
     @patch_settings(TEST_SETTING={})
     def test_invalid_import(self):
         """If the setting isn't a proper string, raise ImproperlyConfigured."""
         with self.assertRaises(ImproperlyConfigured):
-            import_function_from_setting('TEST_SETTING')
+            import_from_setting('TEST_SETTING')
 
     @patch('django_browserid.util.import_module')
     @patch_settings(TEST_SETTING='foo.bar.baz')
@@ -41,7 +41,7 @@ class ImportFunctionFromSettingTests(TestCase):
         """If there is an error importing the module, raise ImproperlyConfigured."""
         import_module.side_effect = ImportError
         with self.assertRaises(ImproperlyConfigured):
-            import_function_from_setting('TEST_SETTING')
+            import_from_setting('TEST_SETTING')
         import_module.assert_called_with('foo.bar')
 
     @patch('django_browserid.util.import_module')
@@ -50,7 +50,7 @@ class ImportFunctionFromSettingTests(TestCase):
         """If there is an error importing the module, raise ImproperlyConfigured."""
         import_module.side_effect = ImportError
         with self.assertRaises(ImproperlyConfigured):
-            import_function_from_setting('TEST_SETTING')
+            import_from_setting('TEST_SETTING')
         import_module.assert_called_with('foo.bar')
 
     @patch('django_browserid.util.import_module')
@@ -59,7 +59,7 @@ class ImportFunctionFromSettingTests(TestCase):
         """If the module is imported, but the function isn't found, raise ImproperlyConfigured."""
         import_module.return_value = Mock(spec=[])
         with self.assertRaises(ImproperlyConfigured):
-            import_function_from_setting('TEST_SETTING')
+            import_from_setting('TEST_SETTING')
 
     @patch('django_browserid.util.import_module')
     @patch_settings(TEST_SETTING='foo.bar.baz')
@@ -67,5 +67,5 @@ class ImportFunctionFromSettingTests(TestCase):
         """If the module is imported and has the requested function, return it."""
         module = Mock(spec=['baz'])
         import_module.return_value = module
-        self.assertEqual(import_function_from_setting('TEST_SETTING'), module.baz)
+        self.assertEqual(import_from_setting('TEST_SETTING'), module.baz)
 

--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -125,6 +125,7 @@ def test_redirect_invalid_host():
 
 @patch_settings(DEBUG=True, SESSION_COOKIE_SECURE=True)
 @patch('django_browserid.views.logger.debug')
+@mock_browserid(None)
 def test_sanity_session_cookie(debug):
     # If DEBUG == True and SESSION_COOKIE_SECURE == True, log a debug message
     # warning about it.
@@ -134,6 +135,7 @@ def test_sanity_session_cookie(debug):
 
 @patch_settings(DEBUG=True, MIDDLEWARE_CLASSES=['csp.middleware.CSPMiddleware'])
 @patch('django_browserid.views.logger.debug')
+@mock_browserid(None)
 def test_sanity_csp(debug):
     # If DEBUG == True, the django-csp middleware is present, and Persona isn't
     # allowed by CSP, log a debug message warning about it.

--- a/django_browserid/urls.py
+++ b/django_browserid/urls.py
@@ -11,13 +11,13 @@ except ImportError:
 from django.contrib.auth.views import logout
 from django.core.exceptions import ImproperlyConfigured
 
-from django_browserid.util import import_function_from_setting
+from django_browserid.util import import_from_setting
 
 logger = logging.getLogger(__name__)
 
 
 try:
-    Verify = import_function_from_setting('BROWSERID_VERIFY_CLASS')
+    Verify = import_from_setting('BROWSERID_VERIFY_CLASS')
 except ImproperlyConfigured as e:
     logger.info('Loading BROWSERID_VERIFY_CLASS failed: {0}.\nFalling back to '
                 'default.'.format(e))

--- a/django_browserid/util.py
+++ b/django_browserid/util.py
@@ -21,9 +21,9 @@ class LazyEncoder(json.JSONEncoder):
         return super(LazyEncoder, self).default(obj)
 
 
-def import_function_from_setting(setting):
+def import_from_setting(setting):
     """
-    Attempt to load a function from a module as specified by a setting.
+    Attempt to load a module attribute from a module as specified by a setting.
 
     :raises:
         ImproperlyConfigured if anything goes wrong.
@@ -42,13 +42,12 @@ def import_function_from_setting(setting):
     try:
         mod = import_module(module)
     except ImportError as e:
-        raise ImproperlyConfigured('Error importing `{0}` function: {1}'.format(path, e))
+        raise ImproperlyConfigured('Error importing `{0}`: {1}'.format(path, e))
 
     try:
         return getattr(mod, attr)
     except AttributeError as e:
-        raise ImproperlyConfigured('Module {0} does not define a {1} function.'
-                                   .format(module, attr))
+        raise ImproperlyConfigured('Module {0} does not define `{1}`.'.format(module, attr))
 
 
 # Attempt to use staticfiles_storage.url to retrieve static file URLs.

--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -19,7 +19,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.views.generic.edit import BaseFormView
 
-from django_browserid.base import BrowserIDException, get_audience, sanity_checks
+from django_browserid.base import BrowserIDException, sanity_checks
 from django_browserid.forms import BrowserIDForm
 
 # Try to import funfactory's reverse and fall back to django's version.
@@ -118,13 +118,9 @@ class Verify(BaseFormView):
             Instance of BrowserIDForm that was submitted by the user.
         """
         self.assertion = form.cleaned_data['assertion']
-        self.audience = get_audience(self.request)
 
         try:
-            self.user = auth.authenticate(
-                assertion=self.assertion,
-                audience=self.audience
-            )
+            self.user = auth.authenticate(request=self.request, assertion=self.assertion)
         except BrowserIDException as e:
             return self.login_failure(e)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/details/advanced.rst
+++ b/docs/details/advanced.rst
@@ -46,12 +46,12 @@ If you want to customize the verification view, you can do so by subclassing
 custom logic.
 
 If you want complete control over account verification, you should create your
-own view and use :func:`django_browserid.verify` to manually verify a
+own view and use :func:`django_browserid.RemoteVerifier` to manually verify a
 BrowserID assertion with something like the following:
 
 .. code-block:: python
 
-   from django_browserid import get_audience, verify
+   from django_browserid import get_audience, RemoteVerifier
    from django_browserid.forms import BrowserIDForm
 
 
@@ -60,12 +60,14 @@ BrowserID assertion with something like the following:
        if request.method == 'POST':
            form = BrowserIDForm(data=request.POST)
            if form.is_valid():
-               result = verify(form.cleaned_data['assertion'], get_audience(request))
+               verifier = RemoteVerifier()
+               result = verifier.verify(form.cleaned_data['assertion'], get_audience(request))
                if result:
                    # check for user account, create account for new users, etc
                    user = my_get_or_create_user(result['email'])
 
-See :func:`django_browserid.verify` for more info on what ``verify`` returns.
+See :func:`django_browserid.RemoteVerifier` for more info on how to use the
+verifier object.
 
 
 Custom User Model

--- a/docs/details/api.rst
+++ b/docs/details/api.rst
@@ -13,10 +13,17 @@ Template Helpers
 .. autofunction:: django_browserid.helpers.browserid_js
 
 
-Verification Functions
-----------------------
+Verification
+------------
 
-.. autofunction:: django_browserid.verify
+.. autoclass:: django_browserid.RemoteVerifier
+   :members: verify
+
+.. autoclass:: django_browserid.base.MockVerifier
+   :members: __init__, verify
+
+.. autoclass:: django_browserid.base.VerificationResult
+   :members: expires
 
 .. autofunction:: django_browserid.get_audience
 

--- a/docs/details/settings.rst
+++ b/docs/details/settings.rst
@@ -7,18 +7,22 @@ Settings
 Core Settings
 -------------
 
-.. data:: SITE_URL
+.. data:: BROWSERID_AUDIENCES
 
    **Default:** No default
 
-   Domain and protocol used to access your site. BrowserID uses this value to
-   determine if an assertion was meant for your site.
+   List of audiences that your site accepts. An audience is the protocol,
+   domain name, and (optionally) port that users access your site from. This
+   list is used to determine the audience a user is part of (how they are
+   accessing your site), which is used during verification to ensure that the
+   assertion given to you by the user was intended for your site.
 
-   Can be a string or an iterable of strings.
+   Without this, other sites that the user has authenticated with via Persona
+   could use their assertions to impersonate the user on your site.
 
    Note that this does not have to be a publicly accessible URL, so local URLs
-   like ``localhost:8000`` or ``127.0.0.1`` are acceptable as long as they match
-   what you are using to access your site.
+   like ``http://localhost:8000`` or ``http://127.0.0.1`` are acceptable as
+   long as they match what you are using to access your site.
 
 
 Redirect URLs
@@ -29,7 +33,7 @@ Redirect URLs
     **Default:** ``'/accounts/profile'``
 
     Path to redirect to on successful login. If you don't specify this, the
-    default_ Django value will be used.
+    default Django value will be used.
 
 .. data:: LOGIN_REDIRECT_URL_FAILURE
 
@@ -94,36 +98,8 @@ Customizing the Verify View
 Using a Different Identity Provider
 -----------------------------------
 
-.. data:: BROWSERID_VERIFICATION_URL
-
-    **Default:** ``'https://browserid.org/verify``
-
-    Defines the URL for the BrowserID verification service to use.
-
 .. data:: BROWSERID_SHIM
 
    **Default:** 'https://login.persona.org/include.js'
 
    The URL to use for the BrowserID JavaScript shim.
-
-
-Customizing Verification
-------------------------
-
-.. data:: BROWSERID_DISABLE_CERT_CHECK
-
-    **Default:** ``False``
-
-    Disables SSL certificate verification during BrowserID verification.
-    *Never disable this in production!*
-
-.. data:: BROWSERID_CACERT_FILE
-
-    **Default:** ``None``
-
-    CA cert file used during validation. If none is provided, the default file
-    included with requests_ is used.
-
-.. _requests: http://docs.python-requests.org/
-
-.. _default: https://docs.djangoproject.com/en/dev/ref/settings/#login-redirect-url

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -36,15 +36,12 @@ To use ``django-browserid``, you'll need to make a few changes to your
        # ...
     )
 
-    # Set your site url for security
-    SITE_URL = 'https://example.com'
+    # Specify audiences (protocol, domain, port) that your site will handle.
+    BROWSERID_AUDIENCES = ['http://example.com:8000', 'https://my.example.com']
 
-.. note:: BrowserID uses an assertion and an audience to verify the user. This
-   ``SITE_URL`` is used to determine the audience. It can be a string or an
-   iterable of strings.
-
-   For security reasons, it is
-   *very important* that you set ``SITE_URL`` correctly.
+.. note:: For security reasons, it is *very important* that you set
+   ``BROWSERID_AUDIENCES`` correctly. If it is incorrect, other sites could use
+   assertions to impersonate users on your own site.
 
 .. note:: ``TEMPLATE_CONTEXT_PROCESSORS`` is not in the settings file by
    default. You can find the default value in the `Context Processor


### PR DESCRIPTION
Adds a RemoteVerifier class to replace the verify function. While this makes straight-up verification slightly more clunky (`RemoteVerifier().verify()`), it makes it much easier to swap out alternate verifiers and to customize things like the arguments passed to `requests.post`.

This changes the public API, but we're pre-1.0, suckers!

This also updates `get_audience` to use a setting called `BROWSERID_AUDIENCES` instead of `SITE_URL`. The bad news is that it means you can't develop without this setting (whereas SITE_URL was optional in development), but IMO it's useful to explicitly require an important setting like this at all times. The upside is that I removed a bunch of code around the three or four different types that `SITE_URL` could be, and removed our reliance on a semi-common setting that may be used for several different things. 

Playdoh, for example, can now just use `['http://localhost:8000', 'http://127.0.0.1']` as it's value instead of making the user customize the value.

Other smaller changes:
- Add `tmp` to gitignore. I used this directory for storing a small Django site that uses a develop install of the library, making it easy to test changes on an example site.
- Return a `VerificationResult` from verification instead of a dict. It's more useful!
- Change `import_function_from_setting` to `import_from_setting`. That other name was just obnoxious.

Sorry for dumping such a huge change, but, I mean, the issue is a huge change. Phew!
