### PR TITLE
Fix docs building

### DIFF
--- a/django_browserid/tests/__init__.py
+++ b/django_browserid/tests/__init__.py
@@ -5,8 +5,6 @@ from django.utils.functional import wraps
 
 from mock import patch
 
-from django_browserid.auth import BrowserIDBackend
-from django_browserid.base import MockVerifier
 
 
 def fake_create_user(email):
@@ -37,6 +35,11 @@ class mock_browserid(object):
             Keyword arguments are passed on to :class:`django_browserid.base.MockVerifier`, which
             updates the verification result with them.
         """
+        # Need to import these here so that we can import
+        # django_browserid.tests.settings to build the docs.
+        from django_browserid.auth import BrowserIDBackend
+        from django_browserid.base import MockVerifier
+
         self.patcher = patch.object(BrowserIDBackend, 'get_verifier')
         self.return_value = MockVerifier(email, **kwargs)
 


### PR DESCRIPTION
To build the docs, we have to be able to import
django_browserid.tests.settings. To import that, it first imports
django_browserid.tests.**init** which imports django_browserid.auth
which imports something which requires settings, but that's not loaded
yet, so everything goes down in a firey spiral of doom.

This fixes that by ridiculously importing those two things in the method
they're used rather than at the top level.

r?
