### PR TITLE
Fix json decoding error on python3

### DIFF
--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -194,7 +194,7 @@ class RemoteVerifier(object):
             raise BrowserIDException(err)
 
         try:
-            return VerificationResult(json.loads(response.content))
+            return VerificationResult(response.json())
         except (ValueError, TypeError) as err:
             # If the returned JSON is invalid, log a warning and return a failure result.
             logger.warning('Failed to parse remote verifier response: `{0}`'

--- a/django_browserid/tests/test_base.py
+++ b/django_browserid/tests/test_base.py
@@ -241,7 +241,9 @@ class RemoteVerifierTests(TestCase):
         verifier = base.RemoteVerifier()
 
         with patch('django_browserid.base.requests.post') as post:
-            post.return_value = self._response(content='{asg9=3{{{}}{')
+            response = self._response(content='{asg9=3{{{}}{')
+            response.json.side_effect = ValueError("Couldn't parse json")
+            post.return_value = response
             result = verifier.verify('asdf', 'http://testserver')
         ok_(not result)
         ok_(result.reason.startswith('Could not parse verifier response'))
@@ -253,8 +255,10 @@ class RemoteVerifierTests(TestCase):
         verifier = base.RemoteVerifier()
 
         with patch('django_browserid.base.requests.post') as post:
-            post.return_value = self._response(
+            response = self._response(
                 content='{"status": "okay", "email": "foo@example.com"}')
+            response.json.return_value = {"status": "okay", "email": "foo@example.com"}
+            post.return_value = response
             result = verifier.verify('asdf', 'http://testserver')
         ok_(result)
         eq_(result.email, 'foo@example.com')


### PR DESCRIPTION
response.content is returned as a byte array, and json.loads will choke on it, leading to a failed log-in attempt, which you'll see in the django logs as:

Failed to parse remote verifier response: `b'{"audience":"[redacted]","expires":1387148033218,"issuer":"gmail.login.persona.org","email":"[redacted]","status":"okay"}'`
