### PR TITLE
issue 222 - BROWSERID_AUDIENCES not necessary in debug mode

### DIFF
--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -81,13 +81,17 @@ def get_audience(request):
         :class:`django.core.exceptions.ImproperlyConfigured`: If BROWSERID_AUDIENCES isn't
         defined, or if no matching audience could be found.
     """
-    try:
-        audiences = settings.BROWSERID_AUDIENCES
-    except AttributeError:
-        raise ImproperlyConfigured('Required setting BROWSERID_AUDIENCES not found!')
-
     protocol = 'https' if request.is_secure() else 'http'
     host = '{0}://{1}'.format(protocol, request.get_host())
+    try:
+        audiences = settings.BROWSERID_AUDIENCES
+        if not audiences and settings.DEBUG:
+            return host
+    except AttributeError:
+        if settings.DEBUG:
+            return host
+        raise ImproperlyConfigured('Required setting BROWSERID_AUDIENCES not found!')
+
     for audience in audiences:
         if same_origin(host, audience):
             return audience

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -30,6 +30,7 @@ To use ``django-browserid``, you'll need to make a few changes to your
     )
 
     # Specify audiences (protocol, domain, port) that your site will handle.
+    # Note! This is only needed if DEBUG = False
     BROWSERID_AUDIENCES = ['http://example.com:8000', 'https://my.example.com']
 
 .. note:: For security reasons, it is *very important* that you set


### PR DESCRIPTION
Basically, this makes it possible to have `BROWSERID_AUDIENCES` either unset or set to an empty list. If it is set with some values that's what gets checked. 
