### PR TITLE
Remove support for named URLs; users can use reverse_lazy instead.

### DIFF
--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -10,7 +10,7 @@ from django.test.client import RequestFactory
 from django.utils.encoding import smart_text
 from django.utils.functional import lazy
 
-from mock import ANY, patch
+from mock import patch
 from nose.tools import eq_, ok_
 
 from django_browserid import BrowserIDException, views
@@ -134,14 +134,6 @@ class VerifyTests(TestCase):
         with patch('django_browserid.views.logger.error') as logger_error:
             views.Verify().login_failure(excpt)
         logger_error.assert_called_with(excpt)
-
-    def test_failure_url_reverse(self):
-        # If the failure URL is a view name, it should be reversed
-        # to get the real failure URL.
-        with self.settings(LOGIN_REDIRECT_URL_FAILURE='epic_fail'):
-            response = self.verify('post')
-        eq_(response.status_code, 403)
-        self.assert_json_equals(response.content, {'redirect': '/epic-fail/?bid_login_failed=1'})
 
     @mock_browserid('test@example.com')
     def test_auth_success_redirect_success(self):

--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -5,7 +5,6 @@ import logging
 
 from django.conf import settings
 from django.contrib import auth
-from django.core.urlresolvers import NoReverseMatch
 from django.template import RequestContext
 from django.views.generic import View
 
@@ -72,17 +71,9 @@ class Verify(JSONView):
         if error:
             logger.error(error)
 
-        failure_url = self.failure_url
-
-        # If this url is a view name, we need to reverse it first to
-        # get the url.
-        try:
-            failure_url = reverse(failure_url)
-        except NoReverseMatch:
-            pass
-
         # Append "?bid_login_failed=1" to the URL to notify the
         # JavaScript that the login failed.
+        failure_url = self.failure_url
         if not failure_url.endswith('?'):
             failure_url += '?' if not '?' in failure_url else '&'
         failure_url += 'bid_login_failed=1'

--- a/docs/details/settings.rst
+++ b/docs/details/settings.rst
@@ -28,6 +28,9 @@ Core Settings
 Redirect URLs
 -------------
 
+.. note:: If you want to use named URLs instead of directly including URLs into
+   your settings file, you can use `reverse_lazy`_ to do so.
+
 .. data:: LOGIN_REDIRECT_URL
 
     **Default:** ``'/accounts/profile'``
@@ -46,6 +49,8 @@ Redirect URLs
    **Default:** ``'/'``
 
    Path to redirect to on logout.
+
+.. _reverse_lazy: https://docs.djangoproject.com/en/dev/ref/urlresolvers/#reverse-lazy
 
 
 Customizing the Login Popup


### PR DESCRIPTION
As mentioned in #164, since users can just use `reverse_lazy` to turn named URLs into full URLs in the settings file, we don't need the logic for auto-reversing URLs anymore, so I removed it to keep things simple. 
