### PR TITLE
Fix #199: Test comments to docstrings and use test name for output.

### DIFF
--- a/django_browserid/tests/__init__.py
+++ b/django_browserid/tests/__init__.py
@@ -64,3 +64,8 @@ class mock_browserid(object):
 class TestCase(DjangoTestCase):
     def assert_json_equals(self, json_str, value):
         return eq_(json.loads(smart_text(json_str)), value)
+
+    def shortDescription(self):
+        # Stop nose using the test docstring and instead the test method
+        # name.
+        pass

--- a/django_browserid/tests/test_admin.py
+++ b/django_browserid/tests/test_admin.py
@@ -9,8 +9,10 @@ from django_browserid.tests import TestCase
 
 class BrowserIDAdminSiteTests(TestCase):
     def test_copy_registry(self):
-        # copy_registry should register the ModelAdmins from the given
-        # site on the BrowserIDAdminSite.
+        """
+        copy_registry should register the ModelAdmins from the given
+        site on the BrowserIDAdminSite.
+        """
         django_site = admin.AdminSite()
         browserid_site = BrowserIDAdminSite()
 

--- a/django_browserid/tests/test_auth.py
+++ b/django_browserid/tests/test_auth.py
@@ -38,30 +38,38 @@ class BrowserIDBackendTests(TestCase):
             return backend.authenticate(assertion='asdf', audience='asdf', **kwargs)
 
     def test_failed_verification(self):
-        # If verification fails, return None.
+        """If verification fails, return None."""
         self.assertTrue(self.auth(None) is None)
 
     def test_duplicate_emails(self):
-        # If there are two users with the same email address, return None.
+        """
+        If there are two users with the same email address, return None.
+        """
         new_user('a@example.com', 'test1')
         new_user('a@example.com', 'test2')
         self.assertTrue(self.auth('a@example.com') is None)
 
     def test_auth_success(self):
-        # If a single user is found with the verified email, return an instance
-        # of their user object.
+        """
+        If a single user is found with the verified email, return an
+        instance of their user object.
+        """
         user = new_user('a@example.com')
         self.assertEqual(self.auth('a@example.com'), user)
 
     @patch.object(settings, 'BROWSERID_CREATE_USER', False)
     def test_no_create_user(self):
-        # If user creation is disabled and no user is found, return None.
+        """
+        If user creation is disabled and no user is found, return None.
+        """
         self.assertTrue(self.auth('a@example.com') is None)
 
     @patch.object(settings, 'BROWSERID_CREATE_USER', True)
     def test_create_user(self):
-        # If user creation is enabled and no user is found, return a new
-        # User.
+        """
+        If user creation is enabled and no user is found, return a new
+        User.
+        """
         user = self.auth('a@example.com')
         self.assertTrue(user is not None)
         self.assertTrue(isinstance(user, User))
@@ -71,8 +79,11 @@ class BrowserIDBackendTests(TestCase):
                   'django_browserid.tests.test_auth.new_user')
     @patch('django_browserid.tests.test_auth.new_user')
     def test_custom_create_user(self, create_user):
-        # If user creation is enabled with a custom create function and no user
-        # is found, return the new user created with the custom function.
+        """
+        If user creation is enabled with a custom create function and no
+        user is found, return the new user created with the custom
+        function.
+        """
         create_user.return_value = 'test'
         self.assertEqual(self.auth('a@example.com'), 'test')
         create_user.assert_called_with('a@example.com')
@@ -80,7 +91,7 @@ class BrowserIDBackendTests(TestCase):
     @patch.object(settings, 'BROWSERID_USERNAME_ALGO')
     @patch.object(settings, 'BROWSERID_CREATE_USER', True)
     def test_custom_username_algorithm(self, username_algo):
-        # If a custom username algorithm is specified, use it!
+        """If a custom username algorithm is specified, use it!"""
         username_algo.return_value = 'test'
         user = self.auth('a@b.com')
         self.assertEqual(user.username, 'test')
@@ -88,8 +99,10 @@ class BrowserIDBackendTests(TestCase):
     @patch('django_browserid.auth.user_created')
     @patch.object(settings, 'BROWSERID_CREATE_USER', True)
     def test_user_created_signal(self, user_created):
-        # Test that the user_created signal is called when a new user is
-        # created.
+        """
+        Test that the user_created signal is called when a new user is
+        created.
+        """
         user = self.auth('a@b.com')
         user_created.send.assert_called_with(ANY, user=user)
 
@@ -103,7 +116,9 @@ class BrowserIDBackendTests(TestCase):
         verifier.verify.assert_called_with('asdf', 'http://testserver', foo='bar')
 
     def test_get_user(self):
-        # Check if user returned by BrowserIDBackend.get_user is correct
+        """
+        Check if user returned by BrowserIDBackend.get_user is correct.
+        """
         user = new_user('a@example.com')
         backend = BrowserIDBackend()
         self.assertEqual(backend.get_user(user.pk), user)
@@ -128,8 +143,11 @@ class BrowserIDBackendTests(TestCase):
 
     @patch('django_browserid.auth.logger')
     def test_create_user_integrity_error(self, logger):
-        # If an IntegrityError is raised during user creation, attempt to re-fetch the user in case
-        # the user was created since we checked for the existing account.
+        """
+        If an IntegrityError is raised during user creation, attempt to
+        re-fetch the user in case the user was created since we checked
+        for the existing account.
+        """
         backend = BrowserIDBackend()
         backend.User = Mock()
         error = IntegrityError()

--- a/django_browserid/tests/test_base.py
+++ b/django_browserid/tests/test_base.py
@@ -22,29 +22,37 @@ class SanityCheckTests(TestCase):
 
     @override_settings(DEBUG=True)
     def test_debug_true(self):
-        # If DEBUG is True and BROWSERID_DISABLE_SANITY_CHECKS is not
-        # set, run the checks.
+        """
+        If DEBUG is True and BROWSERID_DISABLE_SANITY_CHECKS is not set,
+        run the checks.
+        """
         request = self.factory.get('/')
         ok_(base.sanity_checks(request))
 
     @override_settings(DEBUG=False)
     def test_debug_false(self):
-        # If DEBUG is True and BROWSERID_DISABLE_SANITY_CHECKS is not
-        # set, run the checks.
+        """
+        If DEBUG is True and BROWSERID_DISABLE_SANITY_CHECKS is not set,
+        run the checks.
+        """
         request = self.factory.get('/')
         ok_(not base.sanity_checks(request))
 
     @override_settings(BROWSERID_DISABLE_SANITY_CHECKS=True)
     def test_disable_sanity_checks(self):
-        # If BROWSERID_DISABLE_SANITY_CHECKS is True, do not run any
-        # checks.
+        """
+        If BROWSERID_DISABLE_SANITY_CHECKS is True, do not run any
+        checks.
+        """
         request = self.factory.get('/')
         ok_(not base.sanity_checks(request))
 
     @override_settings(BROWSERID_DISABLE_SANITY_CHECKS=False, SESSION_COOKIE_SECURE=True)
     def test_sanity_session_cookie(self):
-        # If SESSION_COOKIE_SECURE == True and the current request isn't
-        # https, log a debug message warning about it.
+        """
+        If SESSION_COOKIE_SECURE == True and the current request isn't
+        https, log a debug message warning about it.
+        """
         request = self.factory.get('/')
         request.is_secure = Mock(return_value=False)
         with patch('django_browserid.base.logger.warning') as warning:
@@ -55,8 +63,10 @@ class SanityCheckTests(TestCase):
                        MIDDLEWARE_CLASSES=['csp.middleware.CSPMiddleware'])
     @patch('django_browserid.base.logger.warning')
     def test_sanity_csp(self, warning):
-        # If the django-csp middleware is present and Persona isn't
-        # allowed by CSP, log a debug message warning about it.
+        """
+        If the django-csp middleware is present and Persona isn't
+        allowed by CSP, log a debug message warning about it.
+        """
         request = self.factory.get('/')
 
         # Test if allowed properly.
@@ -96,8 +106,10 @@ class GetAudienceTests(TestCase):
         self.factory = RequestFactory()
 
     def test_setting_missing(self):
-        # If BROWSERID_AUDIENCES isn't defined, raise
-        # ImproperlyConfigured.
+        """
+        If BROWSERID_AUDIENCES isn't defined, raise
+        ImproperlyConfigured.
+        """
         request = self.factory.get('/')
 
         with patch('django_browserid.base.settings') as settings:
@@ -108,8 +120,10 @@ class GetAudienceTests(TestCase):
                 base.get_audience(request)
 
     def test_same_origin_found(self):
-        # If an audience is found in BROWSERID_AUDIENCES with the same
-        # origin as the request URI, return it.
+        """
+        If an audience is found in BROWSERID_AUDIENCES with the same
+        origin as the request URI, return it.
+        """
         request = self.factory.get('http://testserver')
 
         audiences = ['https://example.com', 'http://testserver']
@@ -117,8 +131,10 @@ class GetAudienceTests(TestCase):
             eq_(base.get_audience(request), 'http://testserver')
 
     def test_no_audience(self):
-        # If no matching audiences is found in BROWSERID_AUDIENCES,
-        # raise ImproperlyConfigured.
+        """
+        If no matching audiences is found in BROWSERID_AUDIENCES, raise
+        ImproperlyConfigured.
+        """
         request = self.factory.get('http://testserver')
 
         with self.settings(BROWSERID_AUDIENCES=['https://example.com']):
@@ -126,8 +142,10 @@ class GetAudienceTests(TestCase):
                 base.get_audience(request)
 
     def test_missing_setting_but_in_debug(self):
-        # If no BROWSERID_AUDIENCES is set but in DEBUG just use the
-        # current protocal and host
+        """
+        If no BROWSERID_AUDIENCES is set but in DEBUG just use the
+        current protocal and host.
+        """
         request = self.factory.get('/')
 
         # Simulate that no BROWSERID_AUDIENCES has been set
@@ -137,8 +155,10 @@ class GetAudienceTests(TestCase):
             eq_(base.get_audience(request), 'http://testserver')
 
     def test_no_audience_but_in_debug(self):
-        # If no BROWSERID_AUDIENCES is set but in DEBUG just use the
-        # current protocal and host
+        """
+        If no BROWSERID_AUDIENCES is set but in DEBUG just use the
+        current protocal and host.
+        """
         request = self.factory.get('/')
 
         # Simulate that no BROWSERID_AUDIENCES has been set
@@ -148,49 +168,65 @@ class GetAudienceTests(TestCase):
 
 class VerificationResultTests(TestCase):
     def test_getattr_attribute_exists(self):
-        # If a value exists in the response dict, it should be an
-        # attribute on the result.
+        """
+        If a value exists in the response dict, it should be an
+        attribute on the result.
+        """
         result = base.VerificationResult({'myattr': 'foo'})
         eq_(result.myattr, 'foo')
 
     def test_getattr_attribute_doesnt_exist(self):
-        # If a value doesn't exist in the response dict, accessing it as
-        # an attribute should raise an AttributeError.
+        """
+        If a value doesn't exist in the response dict, accessing it as
+        an attribute should raise an AttributeError.
+        """
         result = base.VerificationResult({'myattr': 'foo'})
         with self.assertRaises(AttributeError):
             result.bar
 
     def test_expires_no_attribute(self):
-        # If no expires attribute was in the response, raise an
-        # AttributeError.
+        """
+        If no expires attribute was in the response, raise an
+        AttributeError.
+        """
         result = base.VerificationResult({'myattr': 'foo'})
         with self.assertRaises(AttributeError):
             result.expires
 
     def test_expires_invalid_timestamp(self):
-        # If the expires attribute cannot be parsed as a timestamp,
-        # return the raw string instead.
+        """
+        If the expires attribute cannot be parsed as a timestamp, return
+        the raw string instead.
+        """
         result = base.VerificationResult({'expires': 'foasdfhas'})
         eq_(result.expires, 'foasdfhas')
 
     def test_expires_valid_timestamp(self):
-        # If expires contains a valid millisecond timestamp, return a
-        # corresponding datetime.
+        """
+        If expires contains a valid millisecond timestamp, return a
+        corresponding datetime.
+        """
         result = base.VerificationResult({'expires': '1379307128000'})
         eq_(datetime(2013, 9, 16, 4, 52, 8), result.expires)
 
     def test_nonzero_failure(self):
-        # If the response status is not 'okay', the result should be
-        # falsy.
+        """
+        If the response status is not 'okay', the result should be
+        falsy.
+        """
         ok_(not base.VerificationResult({'status': 'failure'}))
 
     def test_nonzero_okay(self):
-        # If the response status is 'okay', the result should be truthy.
+        """
+        If the response status is 'okay', the result should be truthy.
+        """
         ok_(base.VerificationResult({'status': 'okay'}))
 
     def test_str_success(self):
-        # If the result is successful, include 'Success' and the email
-        # in the string.
+        """
+        If the result is successful, include 'Success' and the email in
+        the string.
+        """
         result = base.VerificationResult({'status': 'okay', 'email': 'a@example.com'})
         eq_(six.text_type(result), '<VerificationResult Success email=a@example.com>')
 
@@ -199,12 +235,14 @@ class VerificationResultTests(TestCase):
         eq_(six.text_type(result), '<VerificationResult Success>')
 
     def test_str_failure(self):
-        # If the result is a failure, include 'Failure' in the string.
+        """
+        If the result is a failure, include 'Failure' in the string.
+        """
         result = base.VerificationResult({'status': 'failure'})
         eq_(six.text_type(result), '<VerificationResult Failure>')
 
     def test_str_unicode(self):
-        # Ensure that __str__ can handle unicode values.
+        """Ensure that __str__ can handle unicode values."""
         result = base.VerificationResult({'status': 'okay', 'email': six.u('\x80@example.com')})
         eq_(six.text_type(result), six.u('<VerificationResult Success email=\x80@example.com>'))
 
@@ -214,8 +252,10 @@ class RemoteVerifierTests(TestCase):
         return Mock(spec=requests.Response, **kwargs)
 
     def test_verify_requests_parameters(self):
-        # If a subclass overrides requests_parameters, the parameters
-        # should be passed to requests.post.
+        """
+        If a subclass overrides requests_parameters, the parameters
+        should be passed to requests.post.
+        """
         class MyVerifier(base.RemoteVerifier):
             requests_parameters = {'foo': 'bar'}
         verifier = MyVerifier()
@@ -228,8 +268,10 @@ class RemoteVerifierTests(TestCase):
         eq_(post.call_args[1]['foo'], 'bar')
 
     def test_verify_kwargs(self):
-        # Any keyword arguments passed to verify should be passed on as
-        # POST arguments.
+        """
+        Any keyword arguments passed to verify should be passed on as
+        POST arguments.
+        """
         verifier = base.RemoteVerifier()
 
         with patch('django_browserid.base.requests.post') as post:
@@ -241,8 +283,10 @@ class RemoteVerifierTests(TestCase):
         eq_(post.call_args[1]['data']['baz'], 5)
 
     def test_verify_request_exception(self):
-        # If a RequestException is raised during the POST, raise a
-        # BrowserIDException with the RequestException as the cause.
+        """
+        If a RequestException is raised during the POST, raise a
+        BrowserIDException with the RequestException as the cause.
+        """
         verifier = base.RemoteVerifier()
         request_exception = requests.exceptions.RequestException()
 
@@ -254,8 +298,9 @@ class RemoteVerifierTests(TestCase):
         eq_(cm.exception.exc, request_exception)
 
     def test_verify_invalid_json(self):
-        # If the response contains invalid JSON, return a failure
-        # result.
+        """
+        If the response contains invalid JSON, return a failure result.
+        """
         verifier = base.RemoteVerifier()
 
         with patch('django_browserid.base.requests.post') as post:
@@ -268,8 +313,10 @@ class RemoteVerifierTests(TestCase):
 
 
     def test_verify_success(self):
-        # If the response contains valid JSON, return a result object
-        # for that response.
+        """
+        If the response contains valid JSON, return a result object for
+        that response.
+        """
         verifier = base.RemoteVerifier()
 
         with patch('django_browserid.base.requests.post') as post:
@@ -284,16 +331,20 @@ class RemoteVerifierTests(TestCase):
 
 class MockVerifierTests(TestCase):
     def test_verify_no_email(self):
-        # If the given email is None, verify should return a failure
-        # result.
+        """
+        If the given email is None, verify should return a failure
+        result.
+        """
         verifier = base.MockVerifier(None)
         result = verifier.verify('asdf', 'http://testserver')
         ok_(not result)
         eq_(result.reason, 'No email given to MockVerifier.')
 
     def test_verify_email(self):
-        # If an email is given to the constructor, return a successful
-        # result.
+        """
+        If an email is given to the constructor, return a successful
+        result.
+        """
         verifier = base.MockVerifier('a@example.com')
         result = verifier.verify('asdf', 'http://testserver')
         ok_(result)
@@ -301,7 +352,7 @@ class MockVerifierTests(TestCase):
         eq_(result.email, 'a@example.com')
 
     def test_verify_result_attributes(self):
-        # Extra kwargs to the constructor are added to the result.
+        """Extra kwargs to the constructor are added to the result."""
         verifier = base.MockVerifier('a@example.com', foo='bar', baz=5)
         result = verifier.verify('asdf', 'http://testserver')
         eq_(result.foo, 'bar')

--- a/django_browserid/tests/test_helpers.py
+++ b/django_browserid/tests/test_helpers.py
@@ -67,8 +67,10 @@ class BrowserIDLoginTests(TestCase):
         """)
 
     def test_default_class(self):
-        # If no class is provided, it should default to
-        # 'browserid-login persona-button'
+        """
+        If no class is provided, it should default to
+        'browserid-login persona-button'.
+        """
         with self.settings(LOGIN_REDIRECT_URL='/'):
             button = helpers.browserid_login()
         self.assertHTMLEqual(button, """
@@ -87,8 +89,10 @@ class BrowserIDLoginTests(TestCase):
         """)
 
     def test_color_custom_class(self):
-        # If using a color and a custom link class, persona-button
-        # should be added to the link class.
+        """
+        If using a color and a custom link class, persona-button should
+        be added to the link class.
+        """
         with self.settings(LOGIN_REDIRECT_URL='/'):
             button = helpers.browserid_login(link_class='go button', color='dark')
         self.assertHTMLEqual(button, """
@@ -106,7 +110,7 @@ class BrowserIDLoginTests(TestCase):
         """)
 
     def test_next_default(self):
-        # next should default to LOGIN_REDIRECT_URL
+        """next should default to LOGIN_REDIRECT_URL"""
         with self.settings(LOGIN_REDIRECT_URL='/foo/bar'):
             button = helpers.browserid_login()
         self.assertHTMLEqual(button, """
@@ -135,7 +139,7 @@ class BrowserIDLogoutTests(TestCase):
         """)
 
     def test_next_default(self):
-        # next should default to LOGOUT_REDIRECT_URL
+        """next should default to LOGOUT_REDIRECT_URL"""
         with self.settings(LOGOUT_REDIRECT_URL='/foo/bar'):
             button = helpers.browserid_logout()
         self.assertHTMLEqual(button, """

--- a/django_browserid/tests/test_urls.py
+++ b/django_browserid/tests/test_urls.py
@@ -16,7 +16,9 @@ class UrlTests(TestCase):
         self.factory = RequestFactory()
 
     def test_override_verify_class(self):
-        # Reload so that the settings.BROWSERID_VERIFY_CLASS takes effect.
+        """
+        Reload so that the settings.BROWSERID_VERIFY_CLASS takes effect.
+        """
         path = 'django_browserid.tests.test_urls.MyVerifyClass'
         with self.settings(BROWSERID_VERIFY_CLASS=path):
             reload_module(urls)

--- a/django_browserid/tests/test_util.py
+++ b/django_browserid/tests/test_util.py
@@ -32,14 +32,20 @@ class ImportFromSettingTests(TestCase):
 
     @override_settings(TEST_SETTING={})
     def test_invalid_import(self):
-        """If the setting isn't a proper string, raise ImproperlyConfigured."""
+        """
+        If the setting isn't a proper string, raise
+        ImproperlyConfigured.
+        """
         with self.assertRaises(ImproperlyConfigured):
             import_from_setting('TEST_SETTING')
 
     @patch('django_browserid.util.import_module')
     @override_settings(TEST_SETTING='foo.bar.baz')
     def test_failed_import(self, import_module):
-        """If there is an error importing the module, raise ImproperlyConfigured."""
+        """
+        If there is an error importing the module, raise
+        ImproperlyConfigured.
+        """
         import_module.side_effect = ImportError
         with self.assertRaises(ImproperlyConfigured):
             import_from_setting('TEST_SETTING')
@@ -48,7 +54,10 @@ class ImportFromSettingTests(TestCase):
     @patch('django_browserid.util.import_module')
     @override_settings(TEST_SETTING='foo.bar.baz')
     def test_error_importing(self, import_module):
-        """If there is an error importing the module, raise ImproperlyConfigured."""
+        """
+        If there is an error importing the module, raise
+        ImproperlyConfigured.
+        """
         import_module.side_effect = ImportError
         with self.assertRaises(ImproperlyConfigured):
             import_from_setting('TEST_SETTING')
@@ -57,7 +66,10 @@ class ImportFromSettingTests(TestCase):
     @patch('django_browserid.util.import_module')
     @override_settings(TEST_SETTING='foo.bar.baz')
     def test_missing_attribute(self, import_module):
-        """If the module is imported, but the function isn't found, raise ImproperlyConfigured."""
+        """
+        If the module is imported, but the function isn't found, raise
+        ImproperlyConfigured.
+        """
         import_module.return_value = Mock(spec=[])
         with self.assertRaises(ImproperlyConfigured):
             import_from_setting('TEST_SETTING')
@@ -65,7 +77,10 @@ class ImportFromSettingTests(TestCase):
     @patch('django_browserid.util.import_module')
     @override_settings(TEST_SETTING='foo.bar.baz')
     def test_existing_attribute(self, import_module):
-        """If the module is imported and has the requested function, return it."""
+        """
+        If the module is imported and has the requested function,
+        return it.
+        """
         module = Mock(spec=['baz'])
         import_module.return_value = module
         self.assertEqual(import_from_setting('TEST_SETTING'), module.baz)

--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -80,7 +80,7 @@ class VerifyTests(TestCase):
         return response
 
     def test_no_assertion(self):
-        # If no assertion is given, return a failure result.
+        """If no assertion is given, return a failure result."""
         with self.settings(LOGIN_REDIRECT_URL_FAILURE='/fail'):
             response = self.verify('post', blah='asdf')
         eq_(response.status_code, 403)
@@ -88,7 +88,7 @@ class VerifyTests(TestCase):
 
     @mock_browserid(None)
     def test_auth_fail(self):
-        # If authentication fails, redirect to the failure URL.
+        """If authentication fails, redirect to the failure URL."""
         with self.settings(LOGIN_REDIRECT_URL_FAILURE='/fail'):
             response = self.verify('post', assertion='asdf')
         eq_(response.status_code, 403)
@@ -96,7 +96,9 @@ class VerifyTests(TestCase):
 
     @mock_browserid(None)
     def test_auth_fail_url_parameters(self):
-        # Ensure that bid_login_failed=1 is appended to the failure url.
+        """
+        Ensure that bid_login_failed=1 is appended to the failure url.
+        """
         with self.settings(LOGIN_REDIRECT_URL_FAILURE='/fail?'):
             response = self.verify('post', assertion='asdf')
         self.assert_json_equals(response.content, {'redirect': '/fail?bid_login_failed=1'})
@@ -118,7 +120,10 @@ class VerifyTests(TestCase):
     @patch('django_browserid.views.logger.error')
     @patch('django_browserid.views.auth.authenticate')
     def test_authenticate_browserid_exception(self, authenticate, logger_error):
-        # If authenticate raises a BrowserIDException, return a failure response.
+        """
+        If authenticate raises a BrowserIDException, return a failure
+        response.
+        """
         excpt = BrowserIDException(Exception('hsakjw'))
         authenticate.side_effect = excpt
 
@@ -128,7 +133,7 @@ class VerifyTests(TestCase):
         mock_failure.assert_called_with(excpt)
 
     def test_login_failure_log_exception(self):
-        # If login_failure is passed an exception, it should log it.
+        """If login_failure is passed an exception, it should log it."""
         excpt = BrowserIDException(Exception('hsakjw'))
 
         with patch('django_browserid.views.logger.error') as logger_error:
@@ -137,7 +142,7 @@ class VerifyTests(TestCase):
 
     @mock_browserid('test@example.com')
     def test_auth_success_redirect_success(self):
-        # If authentication succeeds, redirect to the success URL.
+        """If authentication succeeds, redirect to the success URL."""
         user = auth.models.User.objects.create_user('asdf', 'test@example.com')
 
         request = self.factory.post('/browserid/verify', {'assertion': 'asdf'})
@@ -152,7 +157,7 @@ class VerifyTests(TestCase):
                                 {'email': 'test@example.com', 'redirect': '/success'})
 
     def test_sanity_checks(self):
-        # Run sanity checks on all incoming requests.
+        """Run sanity checks on all incoming requests."""
         with patch('django_browserid.views.sanity_checks') as sanity_checks:
             self.verify('post')
         ok_(sanity_checks.called)
@@ -200,15 +205,19 @@ class BrowserIDInfoTests(TestCase):
         eq_(response_data['requestArgs'], {'siteName': 'asdf'})
 
     def test_non_browserid_user(self):
-        # If the current user was not authenticated via
-        # django-browserid, userEmail should be empty.
+        """
+        If the current user was not authenticated via django-browserid,
+        userEmail should be empty.
+        """
         user = auth.models.User.objects.create_user('asdf', 'test@example.com')
         response = self.info(user, ModelBackend())
         response_data = json.loads(smart_text(response.content))
         eq_(response_data['userEmail'], '')
 
     def test_lazy_request_args(self):
-        # Ensure that request_args can be a lazy-evaluated dictionary.
+        """
+        Ensure that request_args can be a lazy-evaluated dictionary.
+        """
         def _lazy_request_args():
             return {'siteName': 'asdf'}
         lazy_request_args = lazy(_lazy_request_args, dict)
@@ -224,7 +233,7 @@ class LogoutTests(TestCase):
         self.factory = RequestFactory()
 
     def test_redirect(self):
-        # Include LOGOUT_REDIRECT_URL in the response.
+        """Include LOGOUT_REDIRECT_URL in the response."""
         request = self.factory.post('/')
         logout = views.Logout.as_view()
 


### PR DESCRIPTION
Now, instead of showing the doctoring of a test, nose will show the 
function name of the test. Trick courtesy of andym.

All docstrings that were converted/written as normal comments have been
moved back to docstrings, and wrapped to 72 characters as per PEP8 
recommendations.
