### PR TITLE
Check origin before redirecting users with default JS.

### DIFF
--- a/django_browserid/static/browserid/browserid.js
+++ b/django_browserid/static/browserid/browserid.js
@@ -21,6 +21,18 @@
         }
     }
 
+    /**
+     * Compare the given URL to the current page's URL to see if they share the
+     * same origin.
+     */
+    function matchesCurrentOrigin(url) {
+        var a = document.createElement('a');
+        a.href = url;
+        var hostMatch = !a.host || window.location.host === a.host;
+        var protocolMatch = !a.protocol || window.location.protocol === a.protocol;
+        return hostMatch && protocolMatch;
+    }
+
     $(function() {
         django_browserid.registerWatchHandlers(onAutoLogin);
 
@@ -32,7 +44,10 @@
             window.sessionStorage.browseridLoginAttempt = 'true';
             django_browserid.login().then(function(verifyResult) {
                 window.sessionStorage.browseridLoginAttempt = 'false';
-                window.location = $link.data('next') || verifyResult.redirect;
+                var redirect = $link.data('next') || verifyResult.redirect;
+                if (matchesCurrentOrigin(redirect)) {
+                    window.location = redirect;
+                }
             });
         });
 
@@ -42,7 +57,10 @@
             e.preventDefault();
             var $link = $(this);
             django_browserid.logout().then(function(logoutResult) {
-                window.location = $link.attr('next') || logoutResult.redirect;
+                var redirect = $link.attr('next') || logoutResult.redirect;
+                if (matchesCurrentOrigin(redirect)) {
+                    window.location = redirect;
+                }
             });
         });
     });


### PR DESCRIPTION
Prevents issues like phishing attempts on sites that allow users to post HTML (users posts a link with data-next and the right class, user logs in and then thinks they're on the same site when they got redirected to attack site).
