### PR TITLE
Fix #239: Switch back to using browserid_info for id.request arguments.

### DIFF
--- a/django_browserid/helpers.py
+++ b/django_browserid/helpers.py
@@ -10,6 +10,29 @@ from django.utils.safestring import mark_safe
 from django.utils.six import string_types
 
 from django_browserid.compat import jingo_register, reverse
+from django_browserid.util import LazyEncoder
+
+
+@jingo_register.function
+def browserid_info():
+    """
+    Output the HTML for the info tag, which contains the arguments for
+    navigator.id.request from the BROWSERID_REQUEST_ARGS setting. Should
+    be called once at the top of the page just below the <body> tag.
+    """
+    # Force request_args to be a dictionary, in case it is lazily generated.
+    request_args = dict(getattr(settings, 'BROWSERID_REQUEST_ARGS', {}))
+
+    info = json.dumps({
+        'loginUrl': reverse('browserid.login'),
+        'logoutUrl': reverse('browserid.logout'),
+        'csrfUrl': reverse('browserid.csrf'),
+        'requestArgs': request_args,
+    }, cls=LazyEncoder)
+
+    return render_to_string('browserid/info.html', {
+        'info': info,
+    })
 
 
 def browserid_button(text=None, next=None, link_class=None, attrs=None, href='#'):

--- a/django_browserid/templates/browserid/info.html
+++ b/django_browserid/templates/browserid/info.html
@@ -1,0 +1,5 @@
+{# Store useful data for the JavaScript to use. #}
+<div id="browserid-info"
+     style="display: none;"
+     data-info="{{ info }}">
+</div>

--- a/django_browserid/templatetags/browserid.py
+++ b/django_browserid/templatetags/browserid.py
@@ -9,6 +9,11 @@ register = template.Library()
 
 
 @fancy_tag(register, takes_context=True)
+def browserid_info(context, **kwargs):
+    return helpers.browserid_info(**kwargs)
+
+
+@fancy_tag(register, takes_context=True)
 def browserid_login(context, **kwargs):
     return helpers.browserid_login(**kwargs)
 

--- a/django_browserid/urls.py
+++ b/django_browserid/urls.py
@@ -26,5 +26,5 @@ except ImproperlyConfigured as e:
 urlpatterns = patterns('',
     url(r'^browserid/login/$', Verify.as_view(), name='browserid.login'),
     url(r'^browserid/logout/$', views.Logout.as_view(), name='browserid.logout'),
-    url(r'^browserid/info/$', views.Info.as_view(), name='browserid.info'),
+    url(r'^browserid/csrf/$', views.CsrfToken.as_view(), name='browserid.csrf'),
 )

--- a/docs/api/javascript.rst
+++ b/docs/api/javascript.rst
@@ -52,10 +52,19 @@ django-browserid views on your server.
    .. js:function:: getInfo()
 
       Fetch information from the
-      :attr:`Info view <django_browserid.views.Info>`, such as a CSRF token or
-      the parameters for the Persona popup.
+      :func:`browserid_info <django_browserid.helpers.browserid_info>` tag,
+      such as the parameters for the Persona popup.
 
-      :returns: Deferred that resolves with the results of the AJAX request.
+      :returns: Object containing the data from the info tag.
+
+
+   .. js:function:: getCsrfToken()
+
+      Fetch a CSRF token from the
+      :attr:`CsrfToken view <django_browserid.views.CsrfToken>` via an AJAX
+      request.
+
+      :returns: Deferred that resolves with the CSRF token.
 
 
    .. js:function:: didLoginFail([location])

--- a/docs/api/python.rst
+++ b/docs/api/python.rst
@@ -15,6 +15,8 @@ Template helpers are the functions used in your templates that output HTML for
 login and logout buttons, as well as the CSS and JS tags for making the buttons
 function and display correctly.
 
+.. autofunction:: browserid_info
+
 .. autofunction:: browserid_login
 
 .. autofunction:: browserid_logout
@@ -44,7 +46,7 @@ Views
 
 django-browserid works primarily through AJAX requests to the views below in
 order to log users in and out and to send information required for the login
-process, such as a CSRF token or customization options for the Persona popup.
+process, such as a CSRF token.
 
 .. autoclass:: Verify
    :members:
@@ -54,7 +56,7 @@ process, such as a CSRF token or customization options for the Persona popup.
    :members:
    :show-inheritance:
 
-.. autoclass:: Info
+.. autoclass:: CsrfToken
    :members:
    :show-inheritance:
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -48,8 +48,8 @@ Next, edit your ``urls.py`` file and add the following:
 .. note:: The django-browserid urlconf *must not* have a regex with the
    include. Use a blank string, as shown above.
 
-Finally, you'll need to add the login button to your Django templates, along
-with the CSS and JS files necessary to make it work:
+Finally, you'll need to add the login button and info tag to your Django
+templates, along with the CSS and JS files necessary to make it work:
 
 .. code-block:: html+django
 
@@ -59,6 +59,7 @@ with the CSS and JS files necessary to make it work:
         <link rel="stylesheet" src="{% static 'browserid/persona-buttons.css' %}">
       </head>
       <body>
+        {% browserid_info %}
         {% if user.is_authenticated %}
           <p>Current user: {{ user.email }}</p>
           {% browserid_logout text='Logout' %}
@@ -74,6 +75,9 @@ with the CSS and JS files necessary to make it work:
     </html>
 
 .. note:: ``api.js`` and ``browserid.js`` require `jQuery`_ 1.7 or higher.
+
+.. note:: The ``browserid_info`` tag is required on any page that users can log
+   in from. It's recommended to put it just below the ``<body>`` tag.
 
 And that's it! You can now log into your site using Persona!
 
@@ -95,6 +99,7 @@ written in Jinja2:
         {{ browserid_css() }}
       </head>
       <body>
+        {{ browserid_info() }}
         {% if user.is_authenticated() %}
           <p>Current user: {{ user.email }}</p>
           {{ browserid_logout(text='Logout') }}


### PR DESCRIPTION
Since AJAX is no longer necessary before pulling up the Persona popup, 
popup blocking doesn't block the popup anymore.
