### PR TITLE
match docs to setup.py for requests version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ django-browserid is tested on Python 2.6 to 3.3 and Django 1.4 to 1.6. See
 
 django-browserid depends on:
 
-- Requests_ >= 0.9.1
+- Requests_ >= 1.0.0
 - fancy_tag_ == 0.2.0
 - jQuery_ >= 1.7 (if you are using ``api.js`` and ``browserid.js``).
 


### PR DESCRIPTION
I should have done this when I did [that](https://github.com/mozilla/django-browserid/commit/8a2d717d1e9cb83ef4e9ef86eff15f47f2d66751)
