### PR TITLE
Fix #247: Execute lazy callables for csrf_token within the view.

### DIFF
--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.http import HttpResponse
 from django.template import RequestContext
+from django.utils import six
 from django.views.generic import View
 
 from django_browserid.base import BrowserIDException, sanity_checks
@@ -106,7 +107,10 @@ class CsrfToken(JSONView):
         # pull it from the template context processors via
         # RequestContext.
         context = RequestContext(request)
-        csrf_token = context.get('csrf_token', None)
+
+        # csrf_token might be a lazy value that triggers side-effects,
+        # so we need to force it to a string.
+        csrf_token = six.text_type(context.get('csrf_token', ''))
 
         return HttpResponse(csrf_token)
 


### PR DESCRIPTION
Django’s CSRF middleware does not send a CSRF cookie if the csrf_token
value, which is a lazy-evaluated value, is called. This avoids 
unnecessary cookies, but causes trouble if you don’t evaluate the 
csrf_token within your view.

CsrfToken was doing just that, as it just passed the value to 
HttpResponse, not evaluating csrf_token before the middleware ran and
decided not to send the cookie. By `unicode`ing the value we force it
to run and the middleware sends the cookie as expected.
