### PR TITLE
Fix #248: Fix next param logic and move logic to Python.

### DIFF
--- a/django_browserid/static/browserid/browserid.js
+++ b/django_browserid/static/browserid/browserid.js
@@ -21,18 +21,6 @@
         }
     }
 
-    /**
-     * Compare the given URL to the current page's URL to see if they share the
-     * same origin.
-     */
-    function matchesCurrentOrigin(url) {
-        var a = document.createElement('a');
-        a.href = url;
-        var hostMatch = !a.host || window.location.host === a.host;
-        var protocolMatch = !a.protocol || window.location.protocol === a.protocol;
-        return hostMatch && protocolMatch;
-    }
-
     $(function() {
         django_browserid.registerWatchHandlers(onAutoLogin);
 
@@ -42,12 +30,9 @@
             e.preventDefault();
             var $link = $(this);
             window.sessionStorage.browseridLoginAttempt = 'true';
-            django_browserid.login().then(function(verifyResult) {
+            django_browserid.login($link.data('next')).then(function(verifyResult) {
                 window.sessionStorage.browseridLoginAttempt = 'false';
-                var redirect = $link.data('next') || verifyResult.redirect;
-                if (matchesCurrentOrigin(redirect)) {
-                    window.location = redirect;
-                }
+                window.location = verifyResult.redirect;
             });
         });
 
@@ -56,11 +41,8 @@
         $(document).on('click', '.browserid-logout', function(e) {
             e.preventDefault();
             var $link = $(this);
-            django_browserid.logout().then(function(logoutResult) {
-                var redirect = $link.attr('next') || logoutResult.redirect;
-                if (matchesCurrentOrigin(redirect)) {
-                    window.location = redirect;
-                }
+            django_browserid.logout($link.data('next')).then(function(logoutResult) {
+                window.location = logoutResult.redirect;
             });
         });
     });


### PR DESCRIPTION
By deciding whether to redirect the user to the next param URL or the
default URL in Python instead of JavaScript, we can rely on Django’s
is_safe_url logic.
