### PR TITLE
Fix #243: Document removal of context processor.

### DIFF
--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -29,6 +29,14 @@ a sample config that will log messages from django-browserid to the console:
     }
 
 
+If you recently updated...
+--------------------------
+If you are hitting problems after updating django-browserid, check to make sure
+your installed copy matches the tagged version on Github. In particular,
+leftover ``*.pyc`` files may cause unintended side effects. This is common when
+installing without using a package manager like ``pip``.
+
+
 Nothing happens when clicking the login button
 ----------------------------------------------
 If nothing happens when you click the login button on your website, check that

--- a/docs/user/upgrading.rst
+++ b/docs/user/upgrading.rst
@@ -34,6 +34,10 @@ your site up to the latest and greatest!
           # ...
       )
 
+- Remove ``django_browserid.context_processors.browserid`` from your
+  ``TEMPLATE_CONTEXT_PROCESSORS`` setting, as the context processor no longer
+  exists.
+
 - ``browserid.js`` has been split into ``api.js``, which contains just the
   JavaScript API, and ``browserid.js``, which contains the sample code for
   hooking up login buttons. If you aren't using the ``browserid_js`` helper to


### PR DESCRIPTION
Also adds a small reminder to Troubleshooting about leftover pyx files.
