### PR TITLE
Rework the auto-login docs

### DIFF
--- a/docs/user/extras.rst
+++ b/docs/user/extras.rst
@@ -22,18 +22,16 @@ you specify an email to log the user in with when they click a login button.
 Enable auto-login
 ~~~~~~~~~~~~~~~~~
 
-To enable auto-login on a development machine that's not publicly
-available and never on a publicly available or production machine
-because you know doing so is a **very bad idea**:
+To enable auto-login:
 
-1. add the ``AutoLoginBackend`` class to the ``AUTHENTICATION_BACKENDS`` setting
-2. set :attr:`BROWSERID_AUTOLOGIN_EMAIL <django.conf.settings.BROWSERID_AUTOLOGIN_EMAIL>`
-   to the email you want to be logged in as
-3. set :attr:`BROWSERID_AUTOLOGIN_ENABLED <django.conf.settings.BROWSERID_AUTOLOGIN_ENABLED>`
+1. Add the ``AutoLoginBackend`` class to the ``AUTHENTICATION_BACKENDS`` setting.
+2. Set :attr:`BROWSERID_AUTOLOGIN_EMAIL <django.conf.settings.BROWSERID_AUTOLOGIN_EMAIL>`
+   to the email you want to be logged in as.
+3. Set :attr:`BROWSERID_AUTOLOGIN_ENABLED <django.conf.settings.BROWSERID_AUTOLOGIN_ENABLED>`
    to ``True``.
-4. if you are not using
-   :py:func:`django_browserid.helpers.browserid_js`, you have to
-   manually add ``browserid/autologin.js`` to your site
+4. If you are not using
+   :py:func:`browserid_js template helper <django_browserid.helpers.browserid_js>`,
+   you have to manually add ``browserid/autologin.js`` to your site.
 
 For example:
 
@@ -53,10 +51,10 @@ immediately log you in with the email you set above.
 
 
 Disable auto-login
-------------------
+~~~~~~~~~~~~~~~~~~
 
 To disable auto-login:
 
-1. set :attr:`BROWSERID_AUTOLOGIN_ENABLED <django.conf.settings.BROWSERID_AUTOLOGIN_ENABLED>`
+1. Set :attr:`BROWSERID_AUTOLOGIN_ENABLED <django.conf.settings.BROWSERID_AUTOLOGIN_ENABLED>`
    to ``False``.
-2. if you added ``browserid/autologin.js`` to your site, you must remove it
+2. If you added ``browserid/autologin.js`` to your site, you must remove it.


### PR DESCRIPTION
I reworked the auto-login docs turning the instructions into lists of
steps and breaking up the text into an "enable" section and a "disable"
section. I think this is easier to read. It's certainly easier to
follow.

Further, I think this addresses the confusion around what happens if
you're not using "django_browserid.helpers.browserid_js" regarding
"browserid/autologin.js" since it explicitly addresses it in the
relevant areas as a discrete step.

Fixes #267 

r?
