### PR TITLE
Fix circular import issue with jingo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.6
   - 2.7
-  
+
 env:
   - DJANGO_VERSION=1.4.8
   - DJANGO_VERSION=1.5.4
@@ -19,14 +19,14 @@ matrix:
     - python: 3.3
       env: DJANGO_VERSION=1.6
     - python: 3.2
-      env: DJANGO_VERSION=1.7
+      env: DJANGO_VERSION=1.7.4
     - python: 3.3
-      env: DJANGO_VERSION=1.7
+      env: DJANGO_VERSION=1.7.4
     - python: 3.4
-      env: DJANGO_VERSION=1.7
+      env: DJANGO_VERSION=1.7.4
   exclude:
     - python: 2.6
-      env: DJANGO_VERSION=1.7
+      env: DJANGO_VERSION=1.7.4
 install:
   - pip install django-nose
   - pip install django==${DJANGO_VERSION}

--- a/django_browserid/compat.py
+++ b/django_browserid/compat.py
@@ -13,22 +13,6 @@ except ImportError:
     from django.core.urlresolvers import reverse
 
 
-# Use no-op shims for registering template helpers for jingo if it isn't
-# found.
-class JingoRegister(object):
-    def filter(self, func, *args, **kwargs):
-        return func
-
-    def function(self, func, *args, **kwargs):
-        return func
-
-
-try:
-    from jingo import register as jingo_register
-except ImportError:
-    jingo_register = JingoRegister()
-
-
 # If PyBrowserID is installed, we can support local verification.
 try:
     import browserid

--- a/django_browserid/helpers.py
+++ b/django_browserid/helpers.py
@@ -9,8 +9,9 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.six import string_types
 
-from django_browserid.compat import jingo_register, reverse
+from django_browserid.compat import reverse
 from django_browserid.util import LazyEncoder
+
 
 MANDATORY_LINK_CLASS_LOGIN = 'browserid-login'
 DEFAULT_LINK_CLASS_LOGIN = MANDATORY_LINK_CLASS_LOGIN + ' persona-button'
@@ -18,7 +19,22 @@ MANDATORY_LINK_CLASS_LOGOUT = 'browserid-logout'
 DEFAULT_LINK_CLASS_LOGOUT = MANDATORY_LINK_CLASS_LOGOUT
 
 
-@jingo_register.function
+# Use no-op shims for registering template helpers for jingo if it isn't
+# found.
+class JingoRegister(object):
+    def filter(self, func, *args, **kwargs):
+        return func
+
+    def function(self, func, *args, **kwargs):
+        return func
+
+try:
+    from jingo import register
+except ImportError:
+    register = JingoRegister()
+
+
+@register.function
 def browserid_info():
     """
     Output the HTML for the info tag, which contains the arguments for
@@ -75,7 +91,7 @@ def browserid_button(text=None, next=None, link_class=None, attrs=None, href='#'
     })
 
 
-@jingo_register.function
+@register.function
 def browserid_login(text='Sign in', color=None, next=None,
                     link_class=DEFAULT_LINK_CLASS_LOGIN,
                     attrs=None, fallback_href='#'):
@@ -124,7 +140,7 @@ def browserid_login(text='Sign in', color=None, next=None,
     return browserid_button(text, next, link_class, attrs, fallback_href)
 
 
-@jingo_register.function
+@register.function
 def browserid_logout(text='Sign out', next=None,
                      link_class=DEFAULT_LINK_CLASS_LOGOUT, attrs=None):
     """
@@ -153,7 +169,7 @@ def browserid_logout(text='Sign out', next=None,
                             attrs, reverse('browserid.logout'))
 
 
-@jingo_register.function
+@register.function
 def browserid_js(include_shim=True):
     """
     Return <script> tags for the JavaScript required by the BrowserID login
@@ -191,7 +207,7 @@ def browserid_js(include_shim=True):
     return mark_safe('\n'.join(tags))
 
 
-@jingo_register.function
+@register.function
 def browserid_css():
     """
     Return <link> tag for the optional CSS included with django-browserid.


### PR DESCRIPTION
Turns out jingo imports all apps in INSTALLED_APPS when it’s loaded.
Which loads django_browserid. Which imports django_browserid.compat. 
Which attempts to import jingo, which fails since that’s a circular
import, causing the fake jingo.register shim to be used, which means
the helpers aren’t available in the templates.

The solution? Shove the shim inside helpers.py, which is loaded as late
as possible by jingo to avoid import issues like this.