### PR TITLE
Simplify quickstart HTML template

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -56,7 +56,7 @@ templates, along with the CSS and JS files necessary to make it work:
     {% load browserid %}
     <html>
       <head>
-        <link rel="stylesheet" href="{% static 'browserid/persona-buttons.css' %}">
+        {% browserid_css %}
       </head>
       <body>
         {% browserid_info %}
@@ -69,8 +69,7 @@ templates, along with the CSS and JS files necessary to make it work:
 
         <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
         <script src="https://login.persona.org/include.js"></script>
-        <script src="{% static 'browserid/api.js' %}"></script>
-        <script src="{% static 'browserid/browserid.js' %}"></script>
+        {% browserid_js %}
       </body>
     </html>
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -68,7 +68,6 @@ templates, along with the CSS and JS files necessary to make it work:
         {% endif %}
 
         <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
-        <script src="https://login.persona.org/include.js"></script>
         {% browserid_js %}
       </body>
     </html>


### PR DESCRIPTION
This makes the quickstart HTML template use the `browserid_css` and `browserid_js` template tags, which is useful for a few reasons:

* It simplifies the template code.
* It allows the template to be copy-pasted into an empty file (the existing code is missing a `{% load static %}` but this change removes the need for that).
* It makes the template work automatically with the auto-login system for offline development.