### PR TITLE
Update version specifiers in tox.ini and .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,32 @@ language: python
 python:
   - 2.6
   - 2.7
-
 env:
-  - DJANGO_VERSION=1.4.8
-  - DJANGO_VERSION=1.5.4
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
+  - 'DJANGO_VERSION=">= 1.4, <1.5"'
+  - 'DJANGO_VERSION=">= 1.5, <1.6"'
+  - 'DJANGO_VERSION=">= 1.6, <1.7"'
+  - 'DJANGO_VERSION=">= 1.7, <1.8"'
 matrix:
   include:
     - python: 3.2
-      env: DJANGO_VERSION=1.5.4
+      env: 'DJANGO_VERSION=">= 1.5, <1.6"'
     - python: 3.3
-      env: DJANGO_VERSION=1.5.4
+      env: 'DJANGO_VERSION=">= 1.5, <1.6"'
     - python: 3.2
-      env: DJANGO_VERSION=1.6
+      env: 'DJANGO_VERSION=">= 1.6, <1.7"'
     - python: 3.3
-      env: DJANGO_VERSION=1.6
+      env: 'DJANGO_VERSION=">= 1.6, <1.7"'
     - python: 3.2
-      env: DJANGO_VERSION=1.7.4
+      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
     - python: 3.3
-      env: DJANGO_VERSION=1.7.4
+      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
     - python: 3.4
-      env: DJANGO_VERSION=1.7.4
+      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
   exclude:
     - python: 2.6
-      env: DJANGO_VERSION=1.7.4
+      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
 install:
   - pip install django-nose
-  - pip install django==${DJANGO_VERSION}
+  - pip install "django${DJANGO_VERSION}"
   - pip install -r requirements.txt --use-mirrors
 script: python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -8,84 +8,84 @@ envlist = py26_dj14, py27_dj14, py26_dj15, py27_dj15, py32_dj15, py33_dj15, py26
 
 [testenv:py26_dj14]
 basepython = python2.6
-commands = pip install django<1.5
+commands = pip install 'django>= 1.4, <1.5'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py27_dj14]
 basepython = python2.7
-commands = pip install django<1.5
+commands = pip install 'django>= 1.4, <1.5'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py26_dj15]
 basepython = python2.6
-commands = pip install django<1.6
+commands = pip install 'django>= 1.5, <1.6'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py27_dj15]
 basepython = python2.7
-commands = pip install django<1.6
+commands = pip install 'django>= 1.5, <1.6'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py32_dj15]
 basepython = python3.2
-commands = pip install django<1.6
+commands = pip install 'django>= 1.5, <1.6'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py33_dj15]
 basepython = python3.3
-commands = pip install django<1.6
+commands = pip install 'django>= 1.5, <1.6'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py26_dj16]
 basepython = python2.6
-commands = pip install django==1.6
+commands = pip install 'django>= 1.6, <1.7'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py27_dj16]
 basepython = python2.7
-commands = pip install django==1.6
+commands = pip install 'django>= 1.6, <1.7'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py32_dj16]
 basepython = python3.2
-commands = pip install django==1.6
+commands = pip install 'django>= 1.6, <1.7'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py33_dj16]
 basepython = python3.3
-commands = pip install django==1.6
+commands = pip install 'django>= 1.6, <1.7'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py27_dj17]
 basepython = python2.7
-commands = pip install django==1.7
+commands = pip install 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py32_dj17]
 basepython = python3.2
-commands = pip install django==1.7
+commands = pip install 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py33_dj17]
 basepython = python3.3
-commands = pip install django==1.7
+commands = pip install 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py34_dj17]
 basepython = python3.4
-commands = pip install django==1.7
+commands = pip install 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test


### PR DESCRIPTION
The travis run on #278 failed because Travis was testing us against
Django 1.7 and Python 2.6, which isn't supported. I realized our
version specifiers weren't consistent with eachother and decided to
fix them up.

Now all of the specifiers act like the `~=` operator from PEP 440 and
install the latest compatible version within each major Django version
while testing, which I think better mirrors the versions our users
are going to be using.

This PR is mostly so I can see if Travis likes the changes. :D