### PR TITLE
Clean up broken/non-canonical external links in readme/docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,9 +24,9 @@ Development Guidelines
     72-characters-per-line for documentation/comments. Feel free to break these
     guidelines for readability if necessary.
 
-.. _general Webdev guidelines: http://mozweb.readthedocs.org/en/latest/coding.html#python
-.. _JavaScript guidelines: http://mozweb.readthedocs.org/en/latest/js-style.html#js-style
-.. _CSS guidelines: http://mozweb.readthedocs.org/en/latest/css-style.html
+.. _general Webdev guidelines: http://mozweb.readthedocs.org/en/latest/reference/python-style.html
+.. _JavaScript guidelines: http://mozweb.readthedocs.org/en/latest/reference/js-style.html
+.. _CSS guidelines: http://mozweb.readthedocs.org/en/latest/reference/css-style.html
 
 
 Submitting a Pull Request
@@ -65,5 +65,5 @@ Additional Resources
 
 - Mailing list: `dev-webdev@lists.mozilla.org`_.
 
-.. _irc.mozilla.org: http://irc.mozilla.org
+.. _irc.mozilla.org: https://wiki.mozilla.org/IRC
 .. _dev-webdev@lists.mozilla.org: https://lists.mozilla.org/listinfo/dev-webdev

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ django-browserid
 
 |TravisCI|_
 
-.. |TravisCI| image:: https://secure.travis-ci.org/mozilla/django-browserid.png?branch=master
-.. _TravisCI: https://secure.travis-ci.org/mozilla/django-browserid
+.. |TravisCI| image:: https://travis-ci.org/mozilla/django-browserid.svg?branch=master
+.. _TravisCI: https://travis-ci.org/mozilla/django-browserid
 
 django-browserid is a library that integrates BrowserID_ authentication into
 Django_.
@@ -12,7 +12,7 @@ Django_.
 Supported versions range from Python 2.6 onwards and Django >=1.4.8. For
 more details, check this project's `tox test suite`_ or TravisCI_.
 
-.. _Django: http://www.djangoproject.com/
+.. _Django: https://www.djangoproject.com/
 .. _BrowserID: https://login.persona.org/
 .. _tox test suite: https://github.com/mozilla/django-browserid/blob/master/tox.ini
 
@@ -20,7 +20,7 @@ more details, check this project's `tox test suite`_ or TravisCI_.
 Documentation
 -------------
 
-http://django-browserid.rtfd.org
+http://django-browserid.readthedocs.org/
 
 
 Need Help?
@@ -42,4 +42,4 @@ License
 This software is licensed under the `Mozilla Public License v. 2.0`_. For more
 information, read the file ``LICENSE``.
 
-.. _Mozilla Public License v. 2.0: http://mozilla.org/MPL/2.0/
+.. _Mozilla Public License v. 2.0: https://www.mozilla.org/MPL/2.0/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ django-browserid depends on:
 django-browserid is a work in progress. Contributions are welcome. Feel free
 to fork_ and contribute!
 
-.. _Django: http://www.djangoproject.com/
+.. _Django: https://www.djangoproject.com/
 .. _BrowserID: https://github.com/mozilla/id-specs/blob/prod/browserid/index.md
 .. _Persona: https://persona.org
 .. _tox.ini: https://github.com/mozilla/django-browserid/blob/master/tox.ini

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -157,5 +157,5 @@ you can try asking for help from:
 - The `dev-webdev@lists.mozilla.org`_ mailing list,
 - or by emailing :doc:`the maintainers </contributor/authors>` directly.
 
-.. _irc.mozilla.org: http://irc.mozilla.org
+.. _irc.mozilla.org: https://wiki.mozilla.org/IRC
 .. _dev-webdev@lists.mozilla.org: https://lists.mozilla.org/listinfo/dev-webdev


### PR DESCRIPTION
Fixes a number of links that were either broken or else redirected.