### PR TITLE
Simplify CSRF and Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,16 @@
 language: python
 python:
-  - 2.6
   - 2.7
 env:
-  - 'DJANGO_VERSION=">= 1.4, <1.5"'
-  - 'DJANGO_VERSION=">= 1.5, <1.6"'
-  - 'DJANGO_VERSION=">= 1.6, <1.7"'
-  - 'DJANGO_VERSION=">= 1.7, <1.8"'
-matrix:
-  include:
-    - python: 3.2
-      env: 'DJANGO_VERSION=">= 1.5, <1.6"'
-    - python: 3.3
-      env: 'DJANGO_VERSION=">= 1.5, <1.6"'
-    - python: 3.2
-      env: 'DJANGO_VERSION=">= 1.6, <1.7"'
-    - python: 3.3
-      env: 'DJANGO_VERSION=">= 1.6, <1.7"'
-    - python: 3.2
-      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
-    - python: 3.3
-      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
-    - python: 3.4
-      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
-  exclude:
-    - python: 2.6
-      env: 'DJANGO_VERSION=">= 1.7, <1.8"'
+  - TOX_ENV=py27_dj17
+  - TOX_ENV=py32_dj17
+  - TOX_ENV=py33_dj17
+  - TOX_ENV=py34_dj17
+  - TOX_ENV=py27_dj18
+  - TOX_ENV=py32_dj18
+  - TOX_ENV=py33_dj18
+  - TOX_ENV=py34_dj18
 install:
-  - pip install django-nose
-  - pip install "django${DJANGO_VERSION}"
-  - pip install -r requirements.txt --use-mirrors
-script: python setup.py test
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ django-browserid
 django-browserid is a library that integrates BrowserID_ authentication into
 Django_.
 
-Supported versions range from Python 2.6 onwards and Django >=1.4.8. For
-more details, check this project's `tox test suite`_ or TravisCI_.
+Supported versions include Python 2.7, 3.2, and onward, and Django 1.7 and up.
+For more details, check this project's `tox test suite`_ or TravisCI_.
 
 .. _Django: https://www.djangoproject.com/
 .. _BrowserID: https://login.persona.org/

--- a/django_browserid/tests/__init__.py
+++ b/django_browserid/tests/__init__.py
@@ -8,7 +8,6 @@ from django.utils.encoding import smart_text
 from django.utils.functional import wraps
 
 from mock import patch
-from nose.tools import eq_
 
 from django_browserid.auth import BrowserIDBackend
 from django_browserid.base import MockVerifier
@@ -63,7 +62,7 @@ class mock_browserid(object):
 
 class TestCase(DjangoTestCase):
     def assert_json_equals(self, json_str, value):
-        return eq_(json.loads(smart_text(json_str)), value)
+        return self.assertEqual(json.loads(smart_text(json_str)), value)
 
     def shortDescription(self):
         # Stop nose using the test docstring and instead the test method

--- a/django_browserid/tests/settings.py
+++ b/django_browserid/tests/settings.py
@@ -1,8 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
-
 SECRET_KEY = 'asdf'
 
 DATABASES = {
@@ -13,13 +11,25 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
-    'django_nose',
     'django_browserid',
     'django_browserid.tests',
 
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.staticfiles',
+)
+
+# To make the django app check shut up, we include middleware even if we
+# don't really need it.
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 )
 
 ROOT_URLCONF = 'django_browserid.tests.urls'

--- a/django_browserid/tests/test_helpers.py
+++ b/django_browserid/tests/test_helpers.py
@@ -1,7 +1,6 @@
 from django.utils.functional import lazy
 
 from mock import patch
-from nose.tools import eq_
 
 from django_browserid import helpers
 from django_browserid.tests import TestCase
@@ -22,7 +21,7 @@ class BrowserIDInfoTests(TestCase):
         with self.settings(BROWSERID_REQUEST_ARGS={'foo': 'bar', 'baz': 1}):
             output = helpers.browserid_info()
 
-        eq_(output, self.render_to_string.return_value)
+        self.assertEqual(output, self.render_to_string.return_value)
         expected_info = {
             'loginUrl': '/browserid/login/',
             'logoutUrl': '/browserid/logout/',
@@ -35,7 +34,7 @@ class BrowserIDInfoTests(TestCase):
         with self.settings(BROWSERID_REQUEST_ARGS=lazy_request_args()):
             output = helpers.browserid_info()
 
-        eq_(output, self.render_to_string.return_value)
+        self.assertEqual(output, self.render_to_string.return_value)
         expected_info = {
             'loginUrl': '/browserid/login/',
             'logoutUrl': '/browserid/logout/',

--- a/django_browserid/tests/test_http.py
+++ b/django_browserid/tests/test_http.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from django_browserid.http import JSONResponse
 from django_browserid.tests import TestCase
 
@@ -8,13 +6,13 @@ class JSONResponseTests(TestCase):
     def test_basic(self):
         response = JSONResponse({'blah': 'foo', 'bar': 7})
         self.assert_json_equals(response.content, {'blah': 'foo', 'bar': 7})
-        eq_(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         response = JSONResponse(['baz', {'biff': False}])
         self.assert_json_equals(response.content, ['baz', {'biff': False}])
-        eq_(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_status(self):
         response = JSONResponse({'blah': 'foo', 'bar': 7}, status=404)
         self.assert_json_equals(response.content, {'blah': 'foo', 'bar': 7})
-        eq_(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)

--- a/django_browserid/tests/test_util.py
+++ b/django_browserid/tests/test_util.py
@@ -5,8 +5,6 @@ from django.test.utils import override_settings
 from django.utils import six
 from django.utils.functional import lazy
 
-from nose.tools import eq_
-
 from django_browserid.tests import TestCase
 from django_browserid.util import import_from_setting, LazyEncoder
 
@@ -20,7 +18,7 @@ class TestLazyEncoder(TestCase):
     def test_lazy(self):
         thing = ['foo', lazy_string]
         thing_json = json.dumps(thing, cls=LazyEncoder)
-        eq_('["foo", "blah"]', thing_json)
+        self.assertEqual('["foo", "blah"]', thing_json)
 
 
 import_value = 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ email addresses. django-browserid provides the necessary hooks to get Django
 to authenticate users via BrowserID. By default, django-browserid relies on
 Persona_ for the client-side JavaScript shim and for assertion verification.
 
-django-browserid is tested on Python 2.6 to 3.3 and Django 1.4 to 1.6. See
-`tox.ini`_ for more details.
+django-browserid is tested on Python 2.7 and 3.2 onward, and supports Django
+1.7 and up. See `tox.ini`_ for more details.
 
 django-browserid depends on:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ PyBrowserID>=0.9.2 # Optional, required for building documentation.
 # Tests
 mock>=0.8.0
 Django>=1.3
-nose>=1.3.6
 
 # Documentation
 sphinx>=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyBrowserID>=0.9.2 # Optional, required for building documentation.
 # Tests
 mock>=0.8.0
 Django>=1.3
-django-nose>=1.2
+nose>=1.3.6
 
 # Documentation
 sphinx>=1.2

--- a/runtests.py
+++ b/runtests.py
@@ -1,33 +1,24 @@
-# This file mainly exists to allow python setup.py test to work.
-# http://ericholscher.com/blog/2009/jun/29/enable-setuppy-test-your-django-apps/
 import os
 import sys
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
-os.environ['REUSE_DB'] = '0'
-
-test_dir = os.path.join(os.path.dirname(__file__), 'django_browserid/tests')
-sys.path.insert(0, test_dir)
-
 import django
-
 from django.test.utils import get_runner
 from django.conf import settings
-from django.core.management import call_command
 
 
 def runtests():
-    if django.VERSION >= (1, 7, 0):
-        django.setup()
-        call_command('migrate', interactive=False)
+    test_dir = os.path.join(os.path.dirname(__file__), 'django_browserid/tests')
+    sys.path.insert(0, test_dir)
 
-    else:
-        call_command('syncdb', interactive=False)
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+    os.environ['REUSE_DB'] = '0'
+    django.setup()
 
-    call_command('flush', interactive=False)
-    test_runner = get_runner(settings)
-    failures = test_runner(interactive=False, failfast=False).run_tests([])
-    sys.exit(failures)
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner(interactive=False, failfast=False)
+    failures = test_runner.run_tests(['django_browserid.tests'])
+
+    sys.exit(bool(failures))
 
 if __name__ == '__main__':
     runtests()

--- a/tox.ini
+++ b/tox.ini
@@ -4,88 +4,53 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26_dj14, py27_dj14, py26_dj15, py27_dj15, py32_dj15, py33_dj15, py26_dj16, py27_dj16, py32_dj16, py33_dj16, py27_dj17, py32_dj17, py33_dj17, py34_dj17
+envlist = py27_dj17, py32_dj17, py33_dj17, py34_dj17, py27_dj18, py32_dj18, py33_dj18, py34_dj18
 
-[testenv:py26_dj14]
-basepython = python2.6
-commands = pip install 'django>= 1.4, <1.5'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py27_dj14]
-basepython = python2.7
-commands = pip install 'django>= 1.4, <1.5'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py26_dj15]
-basepython = python2.6
-commands = pip install 'django>= 1.5, <1.6'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py27_dj15]
-basepython = python2.7
-commands = pip install 'django>= 1.5, <1.6'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py32_dj15]
-basepython = python3.2
-commands = pip install 'django>= 1.5, <1.6'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py33_dj15]
-basepython = python3.3
-commands = pip install 'django>= 1.5, <1.6'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py26_dj16]
-basepython = python2.6
-commands = pip install 'django>= 1.6, <1.7'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py27_dj16]
-basepython = python2.7
-commands = pip install 'django>= 1.6, <1.7'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py32_dj16]
-basepython = python3.2
-commands = pip install 'django>= 1.6, <1.7'
-           pip install -r requirements.txt
-           {envpython} setup.py test
-
-[testenv:py33_dj16]
-basepython = python3.3
-commands = pip install 'django>= 1.6, <1.7'
-           pip install -r requirements.txt
-           {envpython} setup.py test
 
 [testenv:py27_dj17]
 basepython = python2.7
-commands = pip install 'django>= 1.7, <1.8'
+commands = pip install --ignore-installed 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py32_dj17]
 basepython = python3.2
-commands = pip install 'django>= 1.7, <1.8'
+commands = pip install --ignore-installed 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py33_dj17]
 basepython = python3.3
-commands = pip install 'django>= 1.7, <1.8'
+commands = pip install --ignore-installed 'django>= 1.7, <1.8'
            pip install -r requirements.txt
            {envpython} setup.py test
 
 [testenv:py34_dj17]
 basepython = python3.4
-commands = pip install 'django>= 1.7, <1.8'
+commands = pip install --ignore-installed 'django>= 1.7, <1.8'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py27_dj18]
+basepython = python2.7
+commands = pip install --ignore-installed 'django>= 1.8, <1.9'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py32_dj18]
+basepython = python3.2
+commands = pip install --ignore-installed 'django>= 1.8, <1.9'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py33_dj18]
+basepython = python3.3
+commands = pip install --ignore-installed 'django>= 1.8, <1.9'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py34_dj18]
+basepython = python3.4
+commands = pip install --ignore-installed 'django>= 1.8, <1.9'
            pip install -r requirements.txt
            {envpython} setup.py test


### PR DESCRIPTION
This PR does two things:

1. Reduces our set of tested/supported Python and Django versions to Django 1.7 and 1.8 and their supported Python versions. Since 1.8 is the new LTS release we don't need to support 1.4 anymore, and our support of other unsupported Django versions was just holding us back.

   As a part of this, I removed django-nose (as we weren't really using any of it's features) and refactored `runtests.py` to match a bit better the [testing script that Django suggests](https://docs.djangoproject.com/en/1.8/topics/testing/advanced/#using-the-django-test-runner-to-test-reusable-applications). I left nose in because we use some of its helpers and I didn't feel like renaming and reformatting our tests to remove it.

2. Simplify the CSRF view to just check for the two variations of CSRF tokens we care about instead of doing some magic around pulling the token out of the request context. I ran into issues with the existing code while working on Pontoon, which uses django-jinja, which got me looking at it in the first place.