### PR TITLE
Fix #291: Add Django 1.9 support and test against the beta.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
 language: python
-python:
-  - 2.7
-env:
-  - TOX_ENV=py27_dj17
-  - TOX_ENV=py32_dj17
-  - TOX_ENV=py33_dj17
-  - TOX_ENV=py34_dj17
-  - TOX_ENV=py27_dj18
-  - TOX_ENV=py32_dj18
-  - TOX_ENV=py33_dj18
-  - TOX_ENV=py34_dj18
+matrix:
+  include:
+    - python: "2.7"
+      env: TOX_ENV=py27_dj17
+    - python: "3.2"
+      env: TOX_ENV=py32_dj17
+    - python: "3.3"
+      env: TOX_ENV=py33_dj17
+    - python: "3.4"
+      env: TOX_ENV=py34_dj17
+    - python: "2.7"
+      env: TOX_ENV=py27_dj18
+    - python: "3.2"
+      env: TOX_ENV=py32_dj18
+    - python: "3.3"
+      env: TOX_ENV=py33_dj18
+    - python: "3.4"
+      env: TOX_ENV=py34_dj18
+    - python: "2.7"
+      env: TOX_ENV=py27_dj19b1
+    - python: "3.4"
+      env: TOX_ENV=py34_dj19b1
+    - python: "3.5"
+      env: TOX_ENV=py35_dj19b1
 install:
   - pip install tox
 script:

--- a/django_browserid/base.py
+++ b/django_browserid/base.py
@@ -8,11 +8,11 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.http import same_origin
 
 import requests
 
 from django_browserid.compat import pybrowserid_found
+from django_browserid.util import same_origin
 
 
 logger = logging.getLogger(__name__)

--- a/django_browserid/tests/test_util.py
+++ b/django_browserid/tests/test_util.py
@@ -6,7 +6,7 @@ from django.utils import six
 from django.utils.functional import lazy
 
 from django_browserid.tests import TestCase
-from django_browserid.util import import_from_setting, LazyEncoder
+from django_browserid.util import import_from_setting, LazyEncoder, same_origin
 
 
 def _lazy_string():
@@ -64,3 +64,16 @@ class ImportFromSettingTests(TestCase):
         return it.
         """
         self.assertEqual(import_from_setting('TEST_SETTING'), 1)
+
+
+class SameOriginTests(TestCase):
+    def test_match(self):
+        self.assertTrue(same_origin('https://example.com', 'https://example.com'))
+        self.assertTrue(same_origin('https://example.com:80', 'https://example.com:80'))
+        self.assertTrue(same_origin('https://example.com:80/different/path?query=4&five=6',
+                                    'https://example.com:80/no/match#path'))
+
+    def test_no_match(self):
+        self.assertFalse(same_origin('http://example.com', 'http://example.org'))
+        self.assertFalse(same_origin('https://example.com', 'http://example.com'))
+        self.assertFalse(same_origin('http://example.com:443', 'http://example.com:80'))

--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -234,4 +234,4 @@ class CsrfTokenTests(TestCase):
     def test_never_cache(self):
         request = self.factory.get('/browserid/csrf/')
         response = self.view.get(request)
-        self.assertEqual(response['Cache-Control'], 'max-age=0')
+        self.assertTrue('max-age=0' in response['Cache-Control'])

--- a/django_browserid/util.py
+++ b/django_browserid/util.py
@@ -7,6 +7,7 @@ import sys
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import Promise
+from django.utils.six.moves.urllib.parse import urlparse
 
 try:
     from django.utils.encoding import force_unicode as force_text
@@ -53,3 +54,12 @@ def import_from_setting(setting):
         return getattr(mod, attr)
     except AttributeError as e:
         raise ImproperlyConfigured('Module {0} does not define `{1}`.'.format(module, attr))
+
+
+def same_origin(url1, url2):
+    """
+    Checks if two URLs share the same origin, IE the same protocol,
+    host, and port.
+    """
+    p1, p2 = urlparse(url1), urlparse(url2)
+    return (p1.scheme, p1.hostname, p1.port) == (p2.scheme, p2.hostname, p2.port)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27_dj17, py32_dj17, py33_dj17, py34_dj17, py27_dj18, py32_dj18, py33_dj18, py34_dj18
+envlist = py27_dj17, py32_dj17, py33_dj17, py34_dj17, py27_dj18, py32_dj18, py33_dj18, py34_dj18, py27_dj19b1, py34_dj19b1, py35_dj19b1
 
 
 [testenv:py27_dj17]
@@ -52,5 +52,23 @@ commands = pip install --ignore-installed 'django>= 1.8, <1.9'
 [testenv:py34_dj18]
 basepython = python3.4
 commands = pip install --ignore-installed 'django>= 1.8, <1.9'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py27_dj19b1]
+basepython = python2.7
+commands = pip install --ignore-installed 'django==1.9b1'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py34_dj19b1]
+basepython = python3.4
+commands = pip install --ignore-installed 'django==1.9b1'
+           pip install -r requirements.txt
+           {envpython} setup.py test
+
+[testenv:py35_dj19b1]
+basepython = python3.5
+commands = pip install --ignore-installed 'django==1.9b1'
            pip install -r requirements.txt
            {envpython} setup.py test


### PR DESCRIPTION
#291 mentions that `same_origin` doesn't exist in Django 1.9; it was replaced by `is_same_domain`, which is not what we used `same_origin` for. So I replicated the function in our utils. There was also a small issue where extra cache headers were added by the no-cache decorator, so I just altered our test to check for the minimum that we expect from the cache headers.

I also added 1.9b1 to the tox/travis tests. Once 1.9 is out we can update to test against the released version and cut a new bugfix release.

@peterbe r?