### PR TITLE
Use the new style urlpatterns syntax to fix Django deprecation warnings

### DIFF
--- a/django_browserid/urls.py
+++ b/django_browserid/urls.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 
 from django_browserid import views
@@ -22,8 +22,8 @@ except ImproperlyConfigured as e:
     Verify = views.Verify
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^browserid/login/$', Verify.as_view(), name='browserid.login'),
     url(r'^browserid/logout/$', views.Logout.as_view(), name='browserid.logout'),
     url(r'^browserid/csrf/$', views.CsrfToken.as_view(), name='browserid.csrf'),
-)
+]


### PR DESCRIPTION
The `patterns()` syntax is now deprecated:
https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns

And so under Django 1.8 results in warnings:
> django_browserid/urls.py:28: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

Fixes #294.