### PR TITLE
De-duplicate login/logout redirect behaviour

### DIFF
--- a/django_browserid/helpers.py
+++ b/django_browserid/helpers.py
@@ -110,8 +110,8 @@ def browserid_login(text='Sign in', color=None, next=None,
         Supported colors are: `'dark'`, `'blue'`, and `'orange'`.
 
     :param next:
-        URL to redirect users to after they login from this link. If omitted,
-        the LOGIN_REDIRECT_URL setting will be used.
+        URL to redirect users to after they login from this link. Defaults to
+        :attr:`.views.Verify.success_url`.
 
     :param link_class:
         CSS class for the link. Defaults to `browserid-login persona-button`.
@@ -136,7 +136,7 @@ def browserid_login(text='Sign in', color=None, next=None,
         else:
             link_class += ' ' + color
 
-    next = next or getattr(settings, 'LOGIN_REDIRECT_URL', '/')
+    next = next or ''
     return browserid_button(text, next, link_class, attrs, fallback_href)
 
 
@@ -150,6 +150,10 @@ def browserid_logout(text='Sign out', next=None,
         Text to use inside the link. Defaults to 'Sign out', which is not
         localized.
 
+    :param next:
+        URL to redirect users to after they logout from this link. Defaults
+        to :attr:`.views.Logout.redirect_url`.
+
     :param link_class:
         CSS classes for the link. The classes will be appended to the
         default class `browserid-logout`.
@@ -160,7 +164,7 @@ def browserid_logout(text='Sign out', next=None,
 
         If given a string, it is parsed as JSON and is expected to be an object.
     """
-    next = next or getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
+    next = next or ''
 
     if MANDATORY_LINK_CLASS_LOGOUT not in link_class.split(' '):
         link_class += ' ' + MANDATORY_LINK_CLASS_LOGOUT

--- a/django_browserid/tests/test_helpers.py
+++ b/django_browserid/tests/test_helpers.py
@@ -115,10 +115,9 @@ class BrowserIDButtonTests(TestCase):
 
 class BrowserIDLoginTests(TestCase):
     def test_login_class(self):
-        with self.settings(LOGIN_REDIRECT_URL='/'):
-            button = helpers.browserid_login(link_class='go button')
+        button = helpers.browserid_login(link_class='go button')
         self.assertHTMLEqual(button, """
-            <a href="#" class="go button browserid-login" data-next="/">
+            <a href="#" class="go button browserid-login" data-next="">
                 <span>Sign in</span>
             </a>
         """)
@@ -128,19 +127,17 @@ class BrowserIDLoginTests(TestCase):
         If no class is provided, it should default to
         'browserid-login persona-button'.
         """
-        with self.settings(LOGIN_REDIRECT_URL='/'):
-            button = helpers.browserid_login()
+        button = helpers.browserid_login()
         self.assertHTMLEqual(button, """
-            <a href="#" class="browserid-login persona-button" data-next="/">
+            <a href="#" class="browserid-login persona-button" data-next="">
                 <span>Sign in</span>
             </a>
         """)
 
     def test_color_class(self):
-        with self.settings(LOGIN_REDIRECT_URL='/'):
-            button = helpers.browserid_login(color='dark')
+        button = helpers.browserid_login(color='dark')
         self.assertHTMLEqual(button, """
-            <a href="#" class="browserid-login persona-button dark" data-next="/">
+            <a href="#" class="browserid-login persona-button dark" data-next="">
                 <span>Sign in</span>
             </a>
         """)
@@ -150,10 +147,9 @@ class BrowserIDLoginTests(TestCase):
         If using a color and a custom link class, persona-button should
         be added to the link class.
         """
-        with self.settings(LOGIN_REDIRECT_URL='/'):
-            button = helpers.browserid_login(link_class='go button', color='dark')
+        button = helpers.browserid_login(link_class='go button', color='dark')
         self.assertHTMLEqual(button, """
-            <a href="#" class="go button browserid-login persona-button dark" data-next="/">
+            <a href="#" class="go button browserid-login persona-button dark" data-next="">
                 <span>Sign in</span>
             </a>
         """)
@@ -166,39 +162,18 @@ class BrowserIDLoginTests(TestCase):
             </a>
         """)
 
-    def test_next_default(self):
-        """next should default to LOGIN_REDIRECT_URL"""
-        with self.settings(LOGIN_REDIRECT_URL='/foo/bar'):
-            button = helpers.browserid_login()
-        self.assertHTMLEqual(button, """
-            <a href="#" class="browserid-login persona-button" data-next="/foo/bar">
-                <span>Sign in</span>
-            </a>
-        """)
-
 
 class BrowserIDLogoutTests(TestCase):
     def test_logout_class(self):
-        with self.settings(LOGOUT_REDIRECT_URL='/'):
-            button = helpers.browserid_logout(link_class='go button')
+        button = helpers.browserid_logout(link_class='go button')
         self.assertHTMLEqual(button, """
-            <a href="/browserid/logout/" class="go button browserid-logout" data-next="/">
+            <a href="/browserid/logout/" class="go button browserid-logout" data-next="">
                 <span>Sign out</span>
             </a>
         """)
 
     def test_next(self):
         button = helpers.browserid_logout(next='/foo/bar')
-        self.assertHTMLEqual(button, """
-            <a href="/browserid/logout/" class="browserid-logout" data-next="/foo/bar">
-                <span>Sign out</span>
-            </a>
-        """)
-
-    def test_next_default(self):
-        """next should default to LOGOUT_REDIRECT_URL"""
-        with self.settings(LOGOUT_REDIRECT_URL='/foo/bar'):
-            button = helpers.browserid_logout()
         self.assertHTMLEqual(button, """
             <a href="/browserid/logout/" class="browserid-logout" data-next="/foo/bar">
                 <span>Sign out</span>


### PR DESCRIPTION
As raised in #296, ``browserid_login`` and ``browserid_logout`` buttons set a default ``next`` which prevents the documented behaviour of ``Verify.success_url`` and ``Logout.redirect_url`` ever taking effect. The default values duplicate the default behaviour of those properties, causing confusion when attempts to customise the redirect behaviour of these views has no effect.

This change instead uses a blank ``next`` by default, letting the ``Verify.success_url`` and ``Logout.redirect_url`` behaviour be used as appropriate when no ``next`` has been explicitly supplied at the point of creating the button. The default behaviour of the library should be unaffected, but it could affect existing custom JS that mistakenly uses the ``data-next`` attribute of the button instead of the returned ``redirect`` from the API.