### PR TITLE
Fix django-browserid for Django 1.9 with Jinja2

### DIFF
--- a/django_browserid/context_processors.py
+++ b/django_browserid/context_processors.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from functools import partial
+
+from django_browserid import helpers
+from django_browserid.forms import BrowserIDForm
+
+
+def browserid(request):
+    """
+    Context processor that adds django-browserid helpers to the template
+    context.
+    """
+    form = BrowserIDForm(auto_id=False)
+    return {
+        'browserid_form': form,  # For custom buttons.
+        'browserid_info': helpers.browserid_info,
+        'browserid_login': helpers.browserid_login,
+        'browserid_logout': helpers.browserid_logout,
+        'browserid_js': helpers.browserid_js,
+        'browserid_css': helpers.browserid_css
+    }

--- a/django_browserid/forms.py
+++ b/django_browserid/forms.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from django import forms
+from django.conf import settings
+
+try:
+    from django.utils.encoding import smart_bytes
+except ImportError:
+    from django.utils.encoding import smart_str as smart_bytes
+
+FORM_JAVASCRIPT = ('browserid/browserid.js',)
+FORM_CSS = ('browserid/persona-buttons.css',)
+BROWSERID_SHIM = getattr(settings, 'BROWSERID_SHIM',
+                         'https://login.persona.org/include.js')
+
+
+class BrowserIDForm(forms.Form):
+    assertion = forms.CharField(widget=forms.HiddenInput())
+    next = forms.CharField(required=False, widget=forms.HiddenInput())
+
+    class Media:
+        js = FORM_JAVASCRIPT + (BROWSERID_SHIM,)
+
+    def clean_assertion(self):
+        try:
+            return smart_bytes(
+                self.cleaned_data['assertion'],
+                encoding='ascii'
+            )
+        except UnicodeEncodeError:
+            # not ascii :(
+            raise forms.ValidationError('non-ascii string')


### PR DESCRIPTION
* The context processor is missing in the source, but present in the wheel. This PR adds it back with slight modifications.
* The context processor passes the request as the first parameter, but `helpers.browserid_info` doesn't take any parameters. This results in obscure errors when using the library. Removing the `functools.partial` solves the issue.