### PR TITLE
Allow usage of named urls for redirection URLs in the settings.

### DIFF
--- a/django_browserid/tests/test_views.py
+++ b/django_browserid/tests/test_views.py
@@ -122,10 +122,10 @@ class VerifyTests(TestCase):
         If authentication fails, redirect to the failure URL, and resolve
         named URLs.
         """
-        with self.settings(LOGIN_REDIRECT_URL_FAILURE='epic_fail'):
+        with self.settings(LOGIN_REDIRECT_URL_FAILURE='test_url'):
             response = self.verify('post', assertion='asdf')
         self.assertEqual(response.status_code, 403)
-        self.assert_json_equals(response.content, {'redirect': '/epic-fail/'})
+        self.assert_json_equals(response.content, {'redirect': '/some-dummy-url/'})
 
     @mock_browserid('test@example.com')
     def test_auth_success_redirect_success(self):
@@ -152,13 +152,13 @@ class VerifyTests(TestCase):
         user = auth.models.User.objects.create_user('asdf', 'test@example.com')
 
         request = self.factory.post('/browserid/verify', {'assertion': 'asdf'})
-        with self.settings(LOGIN_REDIRECT_URL='epic_fail'):
+        with self.settings(LOGIN_REDIRECT_URL='test_url'):
             with patch('django_browserid.views.auth.login') as login:
                 verify = views.Verify.as_view()
                 response = verify(request)
         self.assertEqual(response.status_code, 200)
         self.assert_json_equals(response.content,
-                                {'email': 'test@example.com', 'redirect': '/epic-fail/'})
+                                {'email': 'test@example.com', 'redirect': '/some-dummy-url/'})
 
     def test_sanity_checks(self):
         """Run sanity checks on all incoming requests."""
@@ -230,11 +230,11 @@ class LogoutTests(TestCase):
         logout = views.Logout.as_view()
         self._get_next.return_value = None
 
-        with self.settings(LOGOUT_REDIRECT_URL='epic_fail'):
+        with self.settings(LOGOUT_REDIRECT_URL='test_url'):
             with patch('django_browserid.views.auth.logout') as auth_logout:
                 response = logout(request)
         self.assertEqual(response.status_code, 200)
-        self.assert_json_equals(response.content, {'redirect': '/epic-fail/'})
+        self.assert_json_equals(response.content, {'redirect': '/some-dummy-url/'})
 
     def test_redirect_next(self):
         """

--- a/django_browserid/tests/urls.py
+++ b/django_browserid/tests/urls.py
@@ -8,5 +8,7 @@ from django.http import HttpResponse
 urlpatterns = patterns('',
     (r'', include('django_browserid.urls')),
     url(r'^epic-fail/', lambda r: HttpResponse('this is a stub'),
-        name='epic_fail')
+        name='epic_fail'),
+    url(r'^some-dummy-url/', lambda r: HttpResponse('this is a stub'),
+        name='test_url'),
 )

--- a/django_browserid/views.py
+++ b/django_browserid/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
+from django.shortcuts import resolve_url
 from django.utils.http import is_safe_url
 from django.views.decorators.cache import never_cache
 from django.views.generic import View
@@ -53,7 +54,8 @@ class Verify(JSONView):
         of ``settings.LOGIN_REDIRECT_URL_FAILURE``, and defaults to
         ``'/'`` if the setting doesn't exist.
         """
-        return getattr(settings, 'LOGIN_REDIRECT_URL_FAILURE', '/')
+        return resolve_url(
+            getattr(settings, 'LOGIN_REDIRECT_URL_FAILURE', '/'))
 
     @property
     def success_url(self):
@@ -62,7 +64,7 @@ class Verify(JSONView):
         value of ``settings.LOGIN_REDIRECT_URL``, and defaults to
         ``'/'`` if the setting doesn't exist.
         """
-        return getattr(settings, 'LOGIN_REDIRECT_URL', '/')
+        return resolve_url(getattr(settings, 'LOGIN_REDIRECT_URL', '/'))
 
     def login_success(self):
         """Log the user into the site."""
@@ -126,7 +128,7 @@ class Logout(JSONView):
         ``settings.LOGOUT_REDIRECT_URL`` and defaults to ``/`` if the
         setting isn't found.
         """
-        return getattr(settings, 'LOGOUT_REDIRECT_URL', '/')
+        return resolve_url(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))
 
     def post(self, request):
         """Log the user out."""

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -28,8 +28,9 @@ Core Settings
 
 Redirect URLs
 -------------
-.. note:: If you want to use named URLs instead of directly including URLs into
-   your settings file, you can use `reverse_lazy`_ to do so.
+.. note:: These settings also accepts view function names and named URL
+   patterns which can be used to reduce configuration duplication since you
+   don't have to define the URL in two places (settings and URLconf).
 
 .. attribute:: LOGIN_REDIRECT_URL
 


### PR DESCRIPTION
Since Django 1.7, the `*_REDIRECT_URL` settings can be named URLs, to reduce configuration duplication. This change teaches Django BrowserID about this possibility.

Documentation: https://docs.djangoproject.com/en/1.7/ref/settings/#login-url